### PR TITLE
fix: use runtime discovery for instrumentation.js in post-commit hook

### DIFF
--- a/scripts/install-hook.sh
+++ b/scripts/install-hook.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# ABOUTME: Installs the commit-story git post-commit hook with runtime OTel SDK discovery
-# ABOUTME: Generated hook resolves instrumentation.js at runtime — no hardcoded paths to break
+# ABOUTME: Installs the commit-story git post-commit hook with runtime path discovery
+# ABOUTME: Generated hook resolves the package location at runtime — no hardcoded paths to break
 #
 # Run from the root of a git repository.
 
@@ -20,58 +20,79 @@ if [[ -f "$HOOK_PATH" ]]; then
   echo "⚠️  Warning: $HOOK_PATH already exists"
   echo ""
   echo "To avoid overwriting your existing hook, please add"
-  echo "the following line to your post-commit hook manually:"
-  echo ""
-  echo "    npx commit-story &"
+  echo "the commit-story invocation to your post-commit hook manually."
   echo ""
   exit 1
 fi
 
-# Create the hook with runtime instrumentation discovery
+# Create the hook with runtime package discovery
 cat > "$HOOK_PATH" << 'HOOKEOF'
 #!/bin/bash
 # commit-story post-commit hook
 # Generates a journal entry for each commit
 
-# Discover instrumentation.js at runtime by checking:
+# Resolve symlinks portably (macOS lacks readlink -f)
+resolve_path() {
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$1"
+  elif command -v greadlink >/dev/null 2>&1; then
+    greadlink -f "$1"
+  else
+    cd "$1" && pwd -P
+  fi
+}
+
+# Discover the commit-story package directory at runtime by checking:
 # 1. Local repo (development mode — this IS the commit-story repo)
 # 2. npm link symlink (dev dependency linked to the real repo)
-find_instrumentation() {
+find_package_dir() {
   local repo_root
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || return
 
-  # Check local examples/ (developing commit-story itself)
-  if [[ -f "$repo_root/examples/instrumentation.js" ]]; then
-    echo "$repo_root/examples/instrumentation.js"
+  # Check if this IS the commit-story repo (has src/index.js and package.json with commit-story name)
+  if [[ -f "$repo_root/src/index.js" ]] && grep -q '"commit-story"' "$repo_root/package.json" 2>/dev/null; then
+    echo "$repo_root"
     return
   fi
 
   # Follow npm link symlink to the real package
   local pkg_link="$repo_root/node_modules/commit-story"
   if [[ -L "$pkg_link" ]]; then
-    local real_pkg
-    # Portable symlink resolution (macOS lacks readlink -f)
-    if command -v realpath >/dev/null 2>&1; then
-      real_pkg="$(realpath "$pkg_link")"
-    elif command -v greadlink >/dev/null 2>&1; then
-      real_pkg="$(greadlink -f "$pkg_link")"
-    else
-      real_pkg="$(cd "$pkg_link" && pwd -P)"
-    fi
-    if [[ -f "$real_pkg/examples/instrumentation.js" ]]; then
-      echo "$real_pkg/examples/instrumentation.js"
-      return
-    fi
+    resolve_path "$pkg_link"
+    return
+  fi
+
+  # Installed as a regular dependency
+  if [[ -d "$pkg_link" ]]; then
+    echo "$pkg_link"
+    return
   fi
 }
 
 # Run in background to not block git
 (
-  INSTRUMENT="$(find_instrumentation)"
-  if [[ -n "$INSTRUMENT" ]]; then
-    NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--import '$INSTRUMENT'" npx commit-story
-  else
+  PKG_DIR="$(find_package_dir)"
+
+  if [[ -z "$PKG_DIR" || ! -f "$PKG_DIR/src/index.js" ]]; then
+    # Fallback: try npx (may resolve to an older published version)
     npx commit-story
+    exit
+  fi
+
+  # Build the node command — run the local source directly
+  NODE_ARGS=("$PKG_DIR/src/index.js")
+
+  # Add OTel instrumentation if available
+  if [[ -f "$PKG_DIR/examples/instrumentation.js" ]]; then
+    NODE_ARGS=("--import" "$PKG_DIR/examples/instrumentation.js" "${NODE_ARGS[@]}")
+  fi
+
+  # Inject secrets via vals if .vals.yaml exists in the target repo
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  if [[ -f "$REPO_ROOT/.vals.yaml" ]] && command -v vals >/dev/null 2>&1; then
+    vals exec -f "$REPO_ROOT/.vals.yaml" -- node "${NODE_ARGS[@]}"
+  else
+    node "${NODE_ARGS[@]}"
   fi
 ) &
 HOOKEOF
@@ -83,7 +104,7 @@ echo "✅ Git hook installed successfully"
 echo "   Location: $HOOK_PATH"
 echo ""
 echo "Journal entries will be generated automatically after each commit."
-echo "   OTel SDK: auto-discovered at runtime (if available)"
+echo "   Package & OTel SDK: auto-discovered at runtime"
 echo ""
 echo "To remove the hook, run: npx commit-story-remove"
 echo "Or delete: $HOOK_PATH"

--- a/scripts/install-hook.sh
+++ b/scripts/install-hook.sh
@@ -1,32 +1,12 @@
 #!/usr/bin/env bash
-# ABOUTME: Installs the commit-story git post-commit hook with OTel SDK loading
-# ABOUTME: Resolves instrumentation.js path through symlinks for dev/linked mode
+# ABOUTME: Installs the commit-story git post-commit hook with runtime OTel SDK discovery
+# ABOUTME: Generated hook resolves instrumentation.js at runtime — no hardcoded paths to break
 #
 # Run from the root of a git repository.
 
 set -euo pipefail
 
 HOOK_PATH=".git/hooks/post-commit"
-
-# Resolve this script's real location (follows symlinks from npx/npm link)
-resolve_script_dir() {
-  local source="$1"
-  while [[ -L "$source" ]]; do
-    local dir
-    dir="$(cd "$(dirname "$source")" && pwd)"
-    source="$(readlink "$source")"
-    [[ "$source" != /* ]] && source="$dir/$source"
-  done
-  cd "$(dirname "$source")" && pwd
-}
-
-SCRIPT_DIR="$(resolve_script_dir "$0")"
-EXAMPLES_DIR="$SCRIPT_DIR/../examples"
-if [[ -d "$EXAMPLES_DIR" ]]; then
-  INSTRUMENTATION_PATH="$(cd "$EXAMPLES_DIR" && pwd)/instrumentation.js"
-else
-  INSTRUMENTATION_PATH=""
-fi
 
 # Check if we're in a git repository
 if [[ ! -d ".git" ]]; then
@@ -42,31 +22,52 @@ if [[ -f "$HOOK_PATH" ]]; then
   echo "To avoid overwriting your existing hook, please add"
   echo "the following line to your post-commit hook manually:"
   echo ""
-  if [[ -n "$INSTRUMENTATION_PATH" && -f "$INSTRUMENTATION_PATH" ]]; then
-    echo "    NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--import '$INSTRUMENTATION_PATH'\" npx commit-story &"
-  else
-    echo "    npx commit-story &"
-  fi
+  echo "    npx commit-story &"
   echo ""
   exit 1
 fi
 
-# Build the hook command based on whether instrumentation.js exists (dev/linked mode)
-if [[ -n "$INSTRUMENTATION_PATH" && -f "$INSTRUMENTATION_PATH" ]]; then
-  HOOK_CMD="NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--import '$INSTRUMENTATION_PATH'\" npx commit-story &"
-else
-  HOOK_CMD="npx commit-story &"
-fi
-
-# Create the hook
-cat > "$HOOK_PATH" << EOF
+# Create the hook with runtime instrumentation discovery
+cat > "$HOOK_PATH" << 'HOOKEOF'
 #!/bin/bash
 # commit-story post-commit hook
 # Generates a journal entry for each commit
 
+# Discover instrumentation.js at runtime by checking:
+# 1. Local repo (development mode — this IS the commit-story repo)
+# 2. npm link symlink (dev dependency linked to the real repo)
+find_instrumentation() {
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || return
+
+  # Check local examples/ (developing commit-story itself)
+  if [[ -f "$repo_root/examples/instrumentation.js" ]]; then
+    echo "$repo_root/examples/instrumentation.js"
+    return
+  fi
+
+  # Follow npm link symlink to the real package
+  local pkg_link="$repo_root/node_modules/commit-story"
+  if [[ -L "$pkg_link" ]]; then
+    local real_pkg
+    real_pkg="$(readlink -f "$pkg_link")"
+    if [[ -f "$real_pkg/examples/instrumentation.js" ]]; then
+      echo "$real_pkg/examples/instrumentation.js"
+      return
+    fi
+  fi
+}
+
 # Run in background to not block git
-$HOOK_CMD
-EOF
+(
+  INSTRUMENT="$(find_instrumentation)"
+  if [[ -n "$INSTRUMENT" ]]; then
+    NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--import '$INSTRUMENT'" npx commit-story &
+  else
+    npx commit-story &
+  fi
+) &
+HOOKEOF
 
 # Make it executable
 chmod +x "$HOOK_PATH"
@@ -75,9 +76,7 @@ echo "✅ Git hook installed successfully"
 echo "   Location: $HOOK_PATH"
 echo ""
 echo "Journal entries will be generated automatically after each commit."
-if [[ -n "$INSTRUMENTATION_PATH" && -f "$INSTRUMENTATION_PATH" ]]; then
-  echo "   OTel SDK: enabled (--import instrumentation.js)"
-fi
+echo "   OTel SDK: auto-discovered at runtime (if available)"
 echo ""
 echo "To remove the hook, run: npx commit-story-remove"
 echo "Or delete: $HOOK_PATH"

--- a/scripts/install-hook.sh
+++ b/scripts/install-hook.sh
@@ -69,9 +69,9 @@ find_instrumentation() {
 (
   INSTRUMENT="$(find_instrumentation)"
   if [[ -n "$INSTRUMENT" ]]; then
-    NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--import '$INSTRUMENT'" npx commit-story &
+    NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--import '$INSTRUMENT'" npx commit-story
   else
-    npx commit-story &
+    npx commit-story
   fi
 ) &
 HOOKEOF

--- a/scripts/install-hook.sh
+++ b/scripts/install-hook.sh
@@ -32,12 +32,13 @@ cat > "$HOOK_PATH" << 'HOOKEOF'
 # Generates a journal entry for each commit
 
 # Resolve symlinks portably (macOS lacks readlink -f)
+# NOTE: Fallback method (cd + pwd -P) only works for directory paths/symlinks
 resolve_path() {
-  if command -v realpath >/dev/null 2>&1; then
-    realpath "$1"
-  elif command -v greadlink >/dev/null 2>&1; then
-    greadlink -f "$1"
-  else
+  if command -v realpath >/dev/null 2>&1 && realpath "$1" 2>/dev/null; then
+    return
+  elif command -v greadlink >/dev/null 2>&1 && greadlink -f "$1" 2>/dev/null; then
+    return
+  elif [[ -d "$1" ]] || [[ -L "$1" ]]; then
     cd "$1" && pwd -P
   fi
 }
@@ -50,7 +51,7 @@ find_package_dir() {
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || return
 
   # Check if this IS the commit-story repo (has src/index.js and package.json with commit-story name)
-  if [[ -f "$repo_root/src/index.js" ]] && grep -q '"commit-story"' "$repo_root/package.json" 2>/dev/null; then
+  if [[ -f "$repo_root/src/index.js" ]] && grep -q '"name"[[:space:]]*:[[:space:]]*"commit-story"' "$repo_root/package.json" 2>/dev/null; then
     echo "$repo_root"
     return
   fi

--- a/scripts/install-hook.sh
+++ b/scripts/install-hook.sh
@@ -50,7 +50,14 @@ find_instrumentation() {
   local pkg_link="$repo_root/node_modules/commit-story"
   if [[ -L "$pkg_link" ]]; then
     local real_pkg
-    real_pkg="$(readlink -f "$pkg_link")"
+    # Portable symlink resolution (macOS lacks readlink -f)
+    if command -v realpath >/dev/null 2>&1; then
+      real_pkg="$(realpath "$pkg_link")"
+    elif command -v greadlink >/dev/null 2>&1; then
+      real_pkg="$(greadlink -f "$pkg_link")"
+    else
+      real_pkg="$(cd "$pkg_link" && pwd -P)"
+    fi
     if [[ -f "$real_pkg/examples/instrumentation.js" ]]; then
       echo "$real_pkg/examples/instrumentation.js"
       return

--- a/scripts/uninstall-hook.sh
+++ b/scripts/uninstall-hook.sh
@@ -26,11 +26,9 @@ fi
 if grep -q "npx commit-story" "$HOOK_PATH"; then
   # It's our hook or contains our hook
 
-  # Count lines to see if there's more content
-  LINE_COUNT=$(wc -l < "$HOOK_PATH" | tr -d ' ')
-
-  if [ "$LINE_COUNT" -le 6 ]; then
-    # Simple hook (just ours) - safe to remove
+  # Check if the hook is exclusively ours (contains our marker comment)
+  if grep -q "commit-story post-commit hook" "$HOOK_PATH"; then
+    # Our hook — safe to remove
     rm "$HOOK_PATH"
     echo "✅ Git hook removed successfully"
   else

--- a/tests/scripts/install-hook.test.js
+++ b/tests/scripts/install-hook.test.js
@@ -62,9 +62,8 @@ describe('install-hook.sh', () => {
     execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
 
     const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
-    // Should have a fallback path that runs without --import
-    expect(hookContent).toMatch(/else/);
-    expect(hookContent).toMatch(/npx commit-story/);
+    // The else branch should run npx commit-story without --import
+    expect(hookContent).toMatch(/else[\s\S]*?npx commit-story/);
   });
 
   it('does not contain hardcoded absolute paths', () => {
@@ -88,7 +87,8 @@ describe('install-hook.sh', () => {
     execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
 
     const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
-    expect(hookContent).toMatch(/npx commit-story\s*(&|.*&)/);
+    // The outer subshell is backgrounded with ) &
+    expect(hookContent).toMatch(/\)\s*&/);
   });
 
   it('refuses to overwrite existing hook', () => {
@@ -120,7 +120,7 @@ describe('install-hook.sh', () => {
     expect(hookContent).toMatch(/\$\{NODE_OPTIONS:\+/);
   });
 
-  it('discovers instrumentation.js through npm link symlinks', () => {
+  it('generates hook with npm link symlink resolution logic', () => {
     // Simulate an npm-linked commit-story package
     fakePackageDir = mkdtempSync(join(tmpdir(), 'commit-story-pkg-'));
     mkdirSync(join(fakePackageDir, 'examples'), { recursive: true });

--- a/tests/scripts/install-hook.test.js
+++ b/tests/scripts/install-hook.test.js
@@ -1,5 +1,5 @@
-// ABOUTME: Tests for install-hook.sh — verifies post-commit hook generation with OTel SDK loading
-// ABOUTME: Covers runtime discovery of instrumentation.js, fallback behavior, and edge cases
+// ABOUTME: Tests for install-hook.sh — verifies post-commit hook generation with runtime discovery
+// ABOUTME: Covers package discovery, OTel instrumentation, vals integration, and edge cases
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
@@ -34,45 +34,53 @@ describe('install-hook.sh', () => {
     expect(existsSync(hookPath)).toBe(true);
   });
 
-  it('includes npx commit-story in hook', () => {
+  it('includes runtime package discovery function', () => {
     execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
 
     const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
-    expect(hookContent).toContain('npx commit-story');
+    expect(hookContent).toContain('find_package_dir');
+    expect(hookContent).toContain('src/index.js');
   });
 
-  it('includes runtime discovery function for instrumentation.js', () => {
+  it('runs local source (node src/index.js) not npx', () => {
     execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
 
     const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
-    // Hook should contain resolution logic, not a hardcoded path
-    expect(hookContent).toContain('find_instrumentation');
-    expect(hookContent).toContain('instrumentation.js');
+    // Primary path runs node with the package's src/index.js
+    expect(hookContent).toContain('NODE_ARGS=("$PKG_DIR/src/index.js")');
   });
 
-  it('uses --import when instrumentation.js is found at runtime', () => {
+  it('adds --import for instrumentation.js when available', () => {
     execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
 
     const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
     expect(hookContent).toContain('--import');
-    expect(hookContent).toContain('NODE_OPTIONS');
+    expect(hookContent).toContain('examples/instrumentation.js');
   });
 
-  it('falls back to no-telemetry mode when instrumentation.js is absent', () => {
+  it('integrates with vals when .vals.yaml exists', () => {
     execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
 
     const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
-    // The else branch should run npx commit-story without --import
-    expect(hookContent).toMatch(/else[\s\S]*?npx commit-story/);
+    expect(hookContent).toContain('vals exec');
+    expect(hookContent).toContain('.vals.yaml');
   });
 
   it('does not contain hardcoded absolute paths', () => {
     execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
 
     const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
-    // Should NOT contain baked-in absolute paths to instrumentation.js
+    // Should NOT contain baked-in absolute paths
     const absolutePathMatch = hookContent.match(/--import\s+'\/[^']+instrumentation\.js'/);
     expect(absolutePathMatch).toBeNull();
+  });
+
+  it('falls back to npx when package directory is not found', () => {
+    execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
+
+    const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
+    // Fallback path uses npx
+    expect(hookContent).toMatch(/npx commit-story/);
   });
 
   it('makes hook executable', () => {
@@ -83,7 +91,7 @@ describe('install-hook.sh', () => {
     expect(stats.mode & 0o111).toBeGreaterThan(0);
   });
 
-  it('runs hook in background (trailing &)', () => {
+  it('runs in background via subshell', () => {
     execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
 
     const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
@@ -92,10 +100,8 @@ describe('install-hook.sh', () => {
   });
 
   it('refuses to overwrite existing hook', () => {
-    // Install once
     execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
 
-    // Second install should fail
     expect(() => {
       execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
     }).toThrow();
@@ -112,29 +118,19 @@ describe('install-hook.sh', () => {
     }
   });
 
-  it('preserves existing NODE_OPTIONS in hook', () => {
-    execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
-
-    const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
-    // Should use ${NODE_OPTIONS:+...} pattern to preserve existing options
-    expect(hookContent).toMatch(/\$\{NODE_OPTIONS:\+/);
-  });
-
   it('generates hook with npm link symlink resolution logic', () => {
-    // Simulate an npm-linked commit-story package
     fakePackageDir = mkdtempSync(join(tmpdir(), 'commit-story-pkg-'));
     mkdirSync(join(fakePackageDir, 'examples'), { recursive: true });
     writeFileSync(join(fakePackageDir, 'examples', 'instrumentation.js'), '// stub');
-    mkdirSync(join(fakePackageDir, 'scripts'), { recursive: true });
+    mkdirSync(join(fakePackageDir, 'src'), { recursive: true });
+    writeFileSync(join(fakePackageDir, 'src', 'index.js'), '// stub');
 
-    // Create a symlink in the tmp repo's node_modules pointing to our fake package
     mkdirSync(join(tmpDir, 'node_modules'), { recursive: true });
     symlinkSync(fakePackageDir, join(tmpDir, 'node_modules', 'commit-story'));
 
     execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
 
     const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
-    // Hook should have the logic to follow node_modules symlinks
     expect(hookContent).toContain('node_modules/commit-story');
   });
 });
@@ -152,12 +148,10 @@ describe('uninstall-hook.sh', () => {
   });
 
   it('removes hook installed by install-hook.sh', () => {
-    // Install
     execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
     const hookPath = join(tmpDir, '.git', 'hooks', 'post-commit');
     expect(existsSync(hookPath)).toBe(true);
 
-    // Uninstall
     execFileSync('bash', [UNINSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
     expect(existsSync(hookPath)).toBe(false);
   });

--- a/tests/scripts/install-hook.test.js
+++ b/tests/scripts/install-hook.test.js
@@ -12,14 +12,19 @@ const UNINSTALL_SCRIPT = join(process.cwd(), 'scripts', 'uninstall-hook.sh');
 
 describe('install-hook.sh', () => {
   let tmpDir;
+  let fakePackageDir;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'commit-story-hook-'));
+    fakePackageDir = null;
     execFileSync('git', ['init'], { cwd: tmpDir, stdio: 'ignore' });
   });
 
   afterEach(() => {
     rmSync(tmpDir, { recursive: true, force: true });
+    if (fakePackageDir && existsSync(fakePackageDir)) {
+      rmSync(fakePackageDir, { recursive: true, force: true });
+    }
   });
 
   it('creates post-commit hook file', () => {
@@ -117,7 +122,7 @@ describe('install-hook.sh', () => {
 
   it('discovers instrumentation.js through npm link symlinks', () => {
     // Simulate an npm-linked commit-story package
-    const fakePackageDir = mkdtempSync(join(tmpdir(), 'commit-story-pkg-'));
+    fakePackageDir = mkdtempSync(join(tmpdir(), 'commit-story-pkg-'));
     mkdirSync(join(fakePackageDir, 'examples'), { recursive: true });
     writeFileSync(join(fakePackageDir, 'examples', 'instrumentation.js'), '// stub');
     mkdirSync(join(fakePackageDir, 'scripts'), { recursive: true });
@@ -131,8 +136,6 @@ describe('install-hook.sh', () => {
     const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
     // Hook should have the logic to follow node_modules symlinks
     expect(hookContent).toContain('node_modules/commit-story');
-
-    rmSync(fakePackageDir, { recursive: true, force: true });
   });
 });
 

--- a/tests/scripts/install-hook.test.js
+++ b/tests/scripts/install-hook.test.js
@@ -1,9 +1,9 @@
 // ABOUTME: Tests for install-hook.sh — verifies post-commit hook generation with OTel SDK loading
-// ABOUTME: Covers hook content, NODE_OPTIONS --import flag, executable permissions, and edge cases
+// ABOUTME: Covers runtime discovery of instrumentation.js, fallback behavior, and edge cases
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, existsSync, statSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, existsSync, statSync, mkdirSync, writeFileSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -36,25 +36,39 @@ describe('install-hook.sh', () => {
     expect(hookContent).toContain('npx commit-story');
   });
 
-  it('includes NODE_OPTIONS with --import for instrumentation.js', () => {
+  it('includes runtime discovery function for instrumentation.js', () => {
     execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
 
     const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
-    expect(hookContent).toContain('NODE_OPTIONS=');
-    expect(hookContent).toContain('--import');
+    // Hook should contain resolution logic, not a hardcoded path
+    expect(hookContent).toContain('find_instrumentation');
     expect(hookContent).toContain('instrumentation.js');
   });
 
-  it('embeds absolute path to instrumentation.js', () => {
+  it('uses --import when instrumentation.js is found at runtime', () => {
     execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
 
     const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
-    const match = hookContent.match(/--import\s+'?([^"&\s']+)'?/);
-    expect(match).toBeTruthy();
-    // Path should be absolute
-    expect(match[1]).toMatch(/^\//);
-    // Should point to the real instrumentation.js in this repo
-    expect(existsSync(match[1])).toBe(true);
+    expect(hookContent).toContain('--import');
+    expect(hookContent).toContain('NODE_OPTIONS');
+  });
+
+  it('falls back to no-telemetry mode when instrumentation.js is absent', () => {
+    execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
+
+    const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
+    // Should have a fallback path that runs without --import
+    expect(hookContent).toMatch(/else/);
+    expect(hookContent).toMatch(/npx commit-story/);
+  });
+
+  it('does not contain hardcoded absolute paths', () => {
+    execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
+
+    const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
+    // Should NOT contain baked-in absolute paths to instrumentation.js
+    const absolutePathMatch = hookContent.match(/--import\s+'\/[^']+instrumentation\.js'/);
+    expect(absolutePathMatch).toBeNull();
   });
 
   it('makes hook executable', () => {
@@ -69,7 +83,7 @@ describe('install-hook.sh', () => {
     execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
 
     const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
-    expect(hookContent).toMatch(/npx commit-story\s*&/);
+    expect(hookContent).toMatch(/npx commit-story\s*(&|.*&)/);
   });
 
   it('refuses to overwrite existing hook', () => {
@@ -99,6 +113,26 @@ describe('install-hook.sh', () => {
     const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
     // Should use ${NODE_OPTIONS:+...} pattern to preserve existing options
     expect(hookContent).toMatch(/\$\{NODE_OPTIONS:\+/);
+  });
+
+  it('discovers instrumentation.js through npm link symlinks', () => {
+    // Simulate an npm-linked commit-story package
+    const fakePackageDir = mkdtempSync(join(tmpdir(), 'commit-story-pkg-'));
+    mkdirSync(join(fakePackageDir, 'examples'), { recursive: true });
+    writeFileSync(join(fakePackageDir, 'examples', 'instrumentation.js'), '// stub');
+    mkdirSync(join(fakePackageDir, 'scripts'), { recursive: true });
+
+    // Create a symlink in the tmp repo's node_modules pointing to our fake package
+    mkdirSync(join(tmpDir, 'node_modules'), { recursive: true });
+    symlinkSync(fakePackageDir, join(tmpDir, 'node_modules', 'commit-story'));
+
+    execFileSync('bash', [INSTALL_SCRIPT], { cwd: tmpDir, stdio: 'pipe' });
+
+    const hookContent = readFileSync(join(tmpDir, '.git', 'hooks', 'post-commit'), 'utf-8');
+    // Hook should have the logic to follow node_modules symlinks
+    expect(hookContent).toContain('node_modules/commit-story');
+
+    rmSync(fakePackageDir, { recursive: true, force: true });
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace hardcoded absolute path in generated post-commit hook with runtime discovery
- Hook now checks local `examples/` dir first, then follows `node_modules/commit-story` symlinks
- Falls back gracefully to no-telemetry mode when instrumentation.js is absent
- Use portable symlink resolution (realpath/greadlink/pwd -P) for macOS compatibility
- Update uninstall-hook.sh to use marker comment detection instead of fragile line count

Closes #57

## Test plan

- [x] 13 hook tests pass (3 new: runtime discovery, no hardcoded paths, npm link symlinks)
- [x] Full suite passes (564 tests)
- [x] Hook reinstalled in this repo with runtime discovery
- [ ] Reinstall hooks in spinybacked-orbweaver and other linked repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Package and instrumentation are now discovered at runtime; instrumentation is applied only when present.
  * Hooks prefer direct runtime invocation and will wrap with vals when repo config exists; fallback to npx when discovery fails.
  * Installer messaging simplified and clearer guidance for existing hooks.
  * Hook backgrounding and removal checks made safer to avoid disrupting custom hooks.

* **Tests**
  * Expanded coverage for runtime discovery, linked-package handling, vals wrapping, fallback behavior, and hook safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->