### PR TITLE
feat: add IS_SCORING_RUN env var to control metrics exporter

### DIFF
--- a/examples/instrumentation.js
+++ b/examples/instrumentation.js
@@ -13,8 +13,11 @@ import { dirname, join } from 'node:path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
 
-// Disable auto-metrics — SDK 2.x auto-instantiates a Metrics SDK
-if (!process.env.OTEL_METRICS_EXPORTER) {
+// Disable auto-metrics — SDK 2.x auto-instantiates a Metrics SDK.
+// For IS scoring runs: set IS_SCORING_RUN=1 to enable the metrics exporter so
+// MET rules can be evaluated. MET rules will fail because spiny-orb produces no
+// OTel metrics by design — this is honest signal, not an instrumentation failure.
+if (!process.env.OTEL_METRICS_EXPORTER && !process.env.IS_SCORING_RUN) {
   process.env.OTEL_METRICS_EXPORTER = 'none';
 }
 


### PR DESCRIPTION
## Summary

- Adds `IS_SCORING_RUN=1` env var support to `examples/instrumentation.js` so IS scoring runs can enable the OTel metrics exporter
- Default behavior (metrics disabled via `OTEL_METRICS_EXPORTER=none`) is unchanged
- MET rules will fail during IS scoring runs because commit-story produces no OTel metrics — this is expected and documented as honest signal

## Test plan

- [ ] Verify `node --import ./examples/instrumentation.js` still sets `OTEL_METRICS_EXPORTER=none` by default
- [ ] Verify `IS_SCORING_RUN=1 node --import ./examples/instrumentation.js` does NOT suppress metrics