### PR TITLE
docs: add deployer OTel SDK setup note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ See [`docs/telemetry/`](docs/telemetry/) for the generated attribute documentati
 
 `commit-story` ships with `@opentelemetry/api` as a peer dependency — a lightweight no-op (~50KB) that does nothing unless an OTel SDK is present. No SDK is bundled in the package; deployers who want trace data bring their own.
 
-An example bootstrap is available at [`examples/instrumentation.js`](examples/instrumentation.js) in the repository. Load it via `node --import` before the application:
+An example bootstrap is available at [`examples/instrumentation.js`](examples/instrumentation.js) in the repository. Load it via `node --import` before the application (requires Node ≥18.18.0):
 
 ```bash
 node --import ./examples/instrumentation.js src/index.js

--- a/README.md
+++ b/README.md
@@ -166,6 +166,18 @@ The schema:
 
 See [`docs/telemetry/`](docs/telemetry/) for the generated attribute documentation.
 
+### Deployer SDK Setup
+
+`commit-story` ships with `@opentelemetry/api` as a peer dependency — a lightweight no-op (~50KB) that does nothing unless an OTel SDK is present. No SDK is bundled in the package; deployers who want trace data bring their own.
+
+An example bootstrap is available at [`examples/instrumentation.js`](examples/instrumentation.js) in the repository. Load it via `node --import` before the application:
+
+```bash
+node --import ./examples/instrumentation.js src/index.js
+```
+
+The example configures OTLP HTTP export, a `SimpleSpanProcessor` (suitable for CLI apps where the process may exit before a batch processor flushes), and graceful shutdown on `SIGTERM`/`SIGINT`/`process.exit()`.
+
 ## Project Status
 
 ### What's Built


### PR DESCRIPTION
## Description

**What does this PR do?**

Adds a "Deployer SDK Setup" subsection to the Telemetry Schema section of the README, explaining that `commit-story` ships with `@opentelemetry/api` only (a lightweight no-op peerDep), that no OTel SDK is bundled, and that `examples/instrumentation.js` is provided as a starting-point bootstrap for deployers who want trace data.

**Why is this change needed?**

Without documentation, deployers have no way to discover that `examples/instrumentation.js` exists or understand the SDK-is-the-deployer's-choice contract. The code changes (`@opentelemetry/sdk-node` moved to devDependencies, `src/instrumentation.js` relocated to `examples/`) were already in place — this is the final piece.

## Related Issues

Addresses spinybacked-orbweaver-eval#23.

## Type of Change

- [x] 📚 Documentation update

## Testing Checklist

- [x] Manual testing performed

**Test results:** README renders correctly. No code behavior changed — documentation only.

## Security Checklist

- [x] No secrets or credentials committed

## Breaking Changes

- [x] No

## Additional Context

**Reviewer Notes:** The package.json and file changes this documents were made in earlier commits — `@opentelemetry/sdk-node` is already only in `devDependencies`, and `instrumentation.js` already lives at `examples/`. This PR closes the documentation gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Deployer SDK Setup" section explaining that the project uses the OpenTelemetry API as a peer dependency and that deployers must provide their own SDK. It describes how to load an instrumentation bootstrap before app startup, shows an example OTLP HTTP exporter and SimpleSpanProcessor configuration, and documents graceful shutdown handling for SIGTERM, SIGINT, and process exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->