### PR TITLE
Add OpenTelemetry instrumentation (30 files)

### DIFF
--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -70,3 +70,33 @@ groups:
     stability: development
     brief: "Agent-discovered span: commit_story.journal.generate_sections"
     span_kind: internal
+  - id: span.commit_story.summary.daily_summary_node
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summary.daily_summary_node"
+    span_kind: internal
+  - id: span.commit_story.summary.generate_daily_summary
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summary.generate_daily_summary"
+    span_kind: internal
+  - id: span.commit_story.summary.weekly_summary_node
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summary.weekly_summary_node"
+    span_kind: internal
+  - id: span.commit_story.summary.generate_weekly_summary
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summary.generate_weekly_summary"
+    span_kind: internal
+  - id: span.commit_story.summary.monthly_summary_node
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summary.monthly_summary_node"
+    span_kind: internal
+  - id: span.commit_story.summary.generate_monthly_summary
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summary.generate_monthly_summary"
+    span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -1,4 +1,25 @@
 groups:
+  - id: registry.commit_story.agent_extensions
+    type: attribute_group
+    display_name: Agent-Created Attributes
+    brief: Attributes created by the instrumentation agent
+    attributes:
+      - id: commit_story.summarize.input_count
+        type: int
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.summarize.input_count"
+      - id: commit_story.summarize.force
+        type: boolean
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.summarize.force"
+      - id: commit_story.summarize.generated_count
+        type: int
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.summarize.generated_count"
+      - id: commit_story.summarize.failed_count
+        type: int
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.summarize.failed_count"
   - id: span.commit_story.context.collect_chat_messages
     type: span
     stability: development
@@ -13,4 +34,19 @@ groups:
     type: span
     stability: development
     brief: "Agent-discovered span: commit_story.git.get_previous_commit_time"
+    span_kind: internal
+  - id: span.commit_story.summarize.run_daily
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summarize.run_daily"
+    span_kind: internal
+  - id: span.commit_story.summarize.run_weekly
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summarize.run_weekly"
+    span_kind: internal
+  - id: span.commit_story.summarize.run_monthly
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summarize.run_monthly"
     span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -1,0 +1,6 @@
+groups:
+  - id: span.commit_story.context.collect_chat_messages
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.context.collect_chat_messages"
+    span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -100,3 +100,8 @@ groups:
     stability: development
     brief: "Agent-discovered span: commit_story.summary.generate_monthly_summary"
     span_kind: internal
+  - id: span.commit_story.context.gather_context
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.context.gather_context"
+    span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -4,3 +4,13 @@ groups:
     stability: development
     brief: "Agent-discovered span: commit_story.context.collect_chat_messages"
     span_kind: internal
+  - id: span.commit_story.git.get_commit_data
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.git.get_commit_data"
+    span_kind: internal
+  - id: span.commit_story.git.get_previous_commit_time
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.git.get_previous_commit_time"
+    span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -36,6 +36,30 @@ groups:
         type: string
         stability: development
         brief: "Agent-discovered attribute: commit_story.mcp.server.version"
+      - id: commit_story.summary.entry_days_count
+        type: int
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.summary.entry_days_count"
+      - id: commit_story.summary.unsummarized_days_count
+        type: int
+        stability: development
+        brief: "Agent-discovered attribute:
+          commit_story.summary.unsummarized_days_count"
+      - id: commit_story.summary.daily_summary_days_count
+        type: int
+        stability: development
+        brief: "Agent-discovered attribute:
+          commit_story.summary.daily_summary_days_count"
+      - id: commit_story.summary.unsummarized_weeks_count
+        type: int
+        stability: development
+        brief: "Agent-discovered attribute:
+          commit_story.summary.unsummarized_weeks_count"
+      - id: commit_story.summary.unsummarized_months_count
+        type: int
+        stability: development
+        brief: "Agent-discovered attribute:
+          commit_story.summary.unsummarized_months_count"
   - id: span.commit_story.context.collect_chat_messages
     type: span
     stability: development
@@ -170,4 +194,29 @@ groups:
     type: span
     stability: development
     brief: "Agent-discovered span: commit_story.journal.ensure_directory"
+    span_kind: internal
+  - id: span.commit_story.summary.get_days_with_entries
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summary.get_days_with_entries"
+    span_kind: internal
+  - id: span.commit_story.summary.find_unsummarized_days
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summary.find_unsummarized_days"
+    span_kind: internal
+  - id: span.commit_story.summary.get_days_with_daily_summaries
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summary.get_days_with_daily_summaries"
+    span_kind: internal
+  - id: span.commit_story.summary.find_unsummarized_weeks
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summary.find_unsummarized_weeks"
+    span_kind: internal
+  - id: span.commit_story.summary.find_unsummarized_months
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summary.find_unsummarized_months"
     span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -105,3 +105,18 @@ groups:
     stability: development
     brief: "Agent-discovered span: commit_story.context.gather_context"
     span_kind: internal
+  - id: span.commit_story.summarize.trigger_auto_summaries
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summarize.trigger_auto_summaries"
+    span_kind: internal
+  - id: span.commit_story.summarize.trigger_auto_weekly
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summarize.trigger_auto_weekly"
+    span_kind: internal
+  - id: span.commit_story.summarize.trigger_auto_monthly
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summarize.trigger_auto_monthly"
+    span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -28,6 +28,14 @@ groups:
         type: string
         stability: development
         brief: "Agent-discovered attribute: commit_story.summary.month_label"
+      - id: commit_story.mcp.server.name
+        type: string
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.mcp.server.name"
+      - id: commit_story.mcp.server.version
+        type: string
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.mcp.server.version"
   - id: span.commit_story.context.collect_chat_messages
     type: span
     stability: development
@@ -152,4 +160,9 @@ groups:
     type: span
     stability: development
     brief: "Agent-discovered span: commit_story.summary.generate_and_save_monthly"
+    span_kind: internal
+  - id: span.commit_story.mcp.start_server
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.mcp.start_server"
     span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -20,6 +20,14 @@ groups:
         type: int
         stability: development
         brief: "Agent-discovered attribute: commit_story.summarize.failed_count"
+      - id: commit_story.summary.week_label
+        type: string
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.summary.week_label"
+      - id: commit_story.summary.month_label
+        type: string
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.summary.month_label"
   - id: span.commit_story.context.collect_chat_messages
     type: span
     stability: development
@@ -129,4 +137,19 @@ groups:
     type: span
     stability: development
     brief: "Agent-discovered span: commit_story.journal.discover_reflections"
+    span_kind: internal
+  - id: span.commit_story.summary.generate_and_save_daily
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summary.generate_and_save_daily"
+    span_kind: internal
+  - id: span.commit_story.summary.generate_and_save_weekly
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summary.generate_and_save_weekly"
+    span_kind: internal
+  - id: span.commit_story.summary.generate_and_save_monthly
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.summary.generate_and_save_monthly"
     span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -166,3 +166,8 @@ groups:
     stability: development
     brief: "Agent-discovered span: commit_story.mcp.start_server"
     span_kind: internal
+  - id: span.commit_story.journal.ensure_directory
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.ensure_directory"
+    span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -50,3 +50,23 @@ groups:
     stability: development
     brief: "Agent-discovered span: commit_story.summarize.run_monthly"
     span_kind: internal
+  - id: span.commit_story.ai.generate_summary
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.ai.generate_summary"
+    span_kind: internal
+  - id: span.commit_story.journal.technical_node
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.technical_node"
+    span_kind: internal
+  - id: span.commit_story.journal.dialogue_node
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.dialogue_node"
+    span_kind: internal
+  - id: span.commit_story.journal.generate_sections
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.generate_sections"
+    span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -120,3 +120,13 @@ groups:
     stability: development
     brief: "Agent-discovered span: commit_story.summarize.trigger_auto_monthly"
     span_kind: internal
+  - id: span.commit_story.journal.save_entry
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.save_entry"
+    span_kind: internal
+  - id: span.commit_story.journal.discover_reflections
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.discover_reflections"
+    span_kind: internal

--- a/spiny-orb-pr-summary.md
+++ b/spiny-orb-pr-summary.md
@@ -1,0 +1,167 @@
+## Summary
+
+- **Files processed**: 30
+- **Committed**: 12
+- **No changes needed**: 18
+
+## Per-File Results
+
+| File | Status | Spans | Attempts | Cost | Libraries | Schema Extensions |
+|------|--------|-------|----------|------|-----------|-------------------|
+| src/collectors/claude-collector.js | success | 1 | 1 | $0.14 | — | `span.commit_story.context.collect_chat_messages` |
+| src/collectors/git-collector.js | success | 2 | 1 | $0.13 | — | `span.commit_story.git.get_commit_data`, `span.commit_story.git.get_previous_commit_time` |
+| src/commands/summarize.js | success | 3 | 1 | $0.21 | — | `span.commit_story.summarize.run_daily`, `span.commit_story.summarize.run_weekly`, `span.commit_story.summarize.run_monthly`, `commit_story.summarize.input_count`, `commit_story.summarize.force`, `commit_story.summarize.generated_count`, `commit_story.summarize.failed_count` |
+| src/generators/journal-graph.js | success | 4 | 3 | $1.52 | `@traceloop/instrumentation-langchain` | `span.commit_story.ai.generate_summary`, `span.commit_story.journal.technical_node`, `span.commit_story.journal.dialogue_node`, `span.commit_story.journal.generate_sections` |
+| src/generators/summary-graph.js | success | 6 | 1 | $0.31 | `@traceloop/instrumentation-langchain` | `span.commit_story.summary.daily_summary_node`, `span.commit_story.summary.generate_daily_summary`, `span.commit_story.summary.weekly_summary_node`, `span.commit_story.summary.generate_weekly_summary`, `span.commit_story.summary.monthly_summary_node`, `span.commit_story.summary.generate_monthly_summary` |
+| src/integrators/context-integrator.js | success | 1 | 1 | $0.11 | — | `span.commit_story.context.gather_context` |
+| src/managers/auto-summarize.js | success | 3 | 1 | $0.17 | — | `span.commit_story.summarize.trigger_auto_summaries`, `span.commit_story.summarize.trigger_auto_weekly`, `span.commit_story.summarize.trigger_auto_monthly` |
+| src/managers/journal-manager.js | success | 2 | 2 | $0.43 | — | `span.commit_story.journal.save_entry`, `span.commit_story.journal.discover_reflections` |
+| src/managers/summary-manager.js | success | 3 | 3 | $1.13 | — | `span.commit_story.summary.generate_and_save_daily`, `span.commit_story.summary.generate_and_save_weekly`, `span.commit_story.summary.generate_and_save_monthly`, `commit_story.summary.week_label`, `commit_story.summary.month_label` |
+| src/mcp/server.js | success | 1 | 1 | $0.13 | `@traceloop/instrumentation-mcp` | `span.commit_story.mcp.start_server`, `commit_story.mcp.server.name`, `commit_story.mcp.server.version` |
+| src/utils/journal-paths.js | success | 1 | 3 | $0.34 | — | `span.commit_story.journal.ensure_directory` |
+| src/utils/summary-detector.js | success | 5 | 2 | $0.41 | — | `span.commit_story.summary.get_days_with_entries`, `span.commit_story.summary.find_unsummarized_days`, `span.commit_story.summary.get_days_with_daily_summaries`, `span.commit_story.summary.find_unsummarized_weeks`, `span.commit_story.summary.find_unsummarized_months`, `commit_story.summary.entry_days_count`, `commit_story.summary.unsummarized_days_count`, `commit_story.summary.daily_summary_days_count`, `commit_story.summary.unsummarized_weeks_count`, `commit_story.summary.unsummarized_months_count` |
+
+**No changes needed** (18 files, 0 spans): src/generators/prompts/guidelines/accessibility.js, src/generators/prompts/guidelines/anti-hallucination.js, src/generators/prompts/guidelines/index.js, src/generators/prompts/sections/daily-summary-prompt.js, src/generators/prompts/sections/dialogue-prompt.js, src/generators/prompts/sections/monthly-summary-prompt.js, src/generators/prompts/sections/summary-prompt.js, src/generators/prompts/sections/technical-decisions-prompt.js, src/generators/prompts/sections/weekly-summary-prompt.js, src/index.js, src/integrators/filters/message-filter.js, src/integrators/filters/sensitive-filter.js, src/integrators/filters/token-filter.js, src/mcp/tools/context-capture-tool.js, src/mcp/tools/reflection-tool.js, src/traceloop-init.js, src/utils/commit-analyzer.js, src/utils/config.js
+
+## Span Category Breakdown
+
+| File | External Calls | Schema-Defined | Service Entry Points | Total Functions |
+|------|---------------|----------------|---------------------|-----------------|
+| src/collectors/claude-collector.js | 0 | 0 | 1 | 8 |
+| src/collectors/git-collector.js | 0 | 0 | 2 | 6 |
+| src/commands/summarize.js | 0 | 0 | 3 | 9 |
+| src/generators/prompts/guidelines/accessibility.js | 0 | 0 | 0 | 0 |
+| src/generators/prompts/guidelines/anti-hallucination.js | 0 | 0 | 0 | 0 |
+| src/generators/prompts/sections/dialogue-prompt.js | 0 | 0 | 0 | 0 |
+| src/generators/prompts/sections/technical-decisions-prompt.js | 0 | 0 | 0 | 0 |
+| src/generators/summary-graph.js | 0 | 0 | 6 | 23 |
+| src/index.js | 0 | 0 | 0 | 9 |
+| src/integrators/context-integrator.js | 0 | 0 | 1 | 3 |
+| src/managers/auto-summarize.js | 0 | 0 | 3 | 4 |
+| src/managers/journal-manager.js | 0 | 0 | 2 | 12 |
+| src/managers/summary-manager.js | 0 | 0 | 3 | 14 |
+| src/mcp/server.js | 0 | 0 | 1 | 2 |
+| src/traceloop-init.js | 0 | 0 | 0 | 0 |
+| src/utils/config.js | 0 | 0 | 0 | 0 |
+| src/utils/journal-paths.js | 0 | 0 | 1 | 12 |
+| src/utils/summary-detector.js | 0 | 0 | 5 | 11 |
+
+## Schema Changes
+
+# Summary of Schema Changes
+## Registry versions
+Baseline: 0.1.0
+
+Head: 0.1.0
+
+## Registry Attributes
+### Added
+- commit_story.mcp.server.name
+- commit_story.mcp.server.version
+- commit_story.summarize.failed_count
+- commit_story.summarize.force
+- commit_story.summarize.generated_count
+- commit_story.summarize.input_count
+- commit_story.summary.daily_summary_days_count
+- commit_story.summary.entry_days_count
+- commit_story.summary.month_label
+- commit_story.summary.unsummarized_days_count
+- commit_story.summary.unsummarized_months_count
+- commit_story.summary.unsummarized_weeks_count
+- commit_story.summary.week_label
+
+
+
+
+### New Span IDs (32)
+
+- `span.commit_story.ai.generate_summary`
+- `span.commit_story.context.collect_chat_messages`
+- `span.commit_story.context.gather_context`
+- `span.commit_story.git.get_commit_data`
+- `span.commit_story.git.get_previous_commit_time`
+- `span.commit_story.journal.dialogue_node`
+- `span.commit_story.journal.discover_reflections`
+- `span.commit_story.journal.ensure_directory`
+- `span.commit_story.journal.generate_sections`
+- `span.commit_story.journal.save_entry`
+- `span.commit_story.journal.technical_node`
+- `span.commit_story.mcp.start_server`
+- `span.commit_story.summarize.run_daily`
+- `span.commit_story.summarize.run_monthly`
+- `span.commit_story.summarize.run_weekly`
+- `span.commit_story.summarize.trigger_auto_monthly`
+- `span.commit_story.summarize.trigger_auto_summaries`
+- `span.commit_story.summarize.trigger_auto_weekly`
+- `span.commit_story.summary.daily_summary_node`
+- `span.commit_story.summary.find_unsummarized_days`
+- `span.commit_story.summary.find_unsummarized_months`
+- `span.commit_story.summary.find_unsummarized_weeks`
+- `span.commit_story.summary.generate_and_save_daily`
+- `span.commit_story.summary.generate_and_save_monthly`
+- `span.commit_story.summary.generate_and_save_weekly`
+- `span.commit_story.summary.generate_daily_summary`
+- `span.commit_story.summary.generate_monthly_summary`
+- `span.commit_story.summary.generate_weekly_summary`
+- `span.commit_story.summary.get_days_with_daily_summaries`
+- `span.commit_story.summary.get_days_with_entries`
+- `span.commit_story.summary.monthly_summary_node`
+- `span.commit_story.summary.weekly_summary_node`
+
+## Review Attention
+
+- **src/generators/summary-graph.js**: 6 spans added (average: 2) — outlier, review recommended
+- **src/utils/summary-detector.js**: 5 spans added (average: 2) — outlier, review recommended
+
+### Advisory Findings
+
+**src/commands/summarize.js**
+- SCH-004 (No Redundant Schema Entries): Attribute key "commit_story.summarize.generated_count" at line 260 appears to be a semantic duplicate of an existing registry entry (judge confidence: 72%). Use registered attribute 'commit_story.context.messages_count' instead, as both measure generated/counted discrete items within the commit_story domain. If 'generated_count' specifically measures AI-generated summaries rather than context messages, consider renaming to 'commit_story.summarize.summaries_count' for semantic clarity, or map it to an existing OpenTelemetry semantic convention if it represents a standard metric like token usage.
+
+**src/index.js**
+- COV-004 (Async Operation Spans): "handleSummarize" (async function) at line 208 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.
+
+**src/managers/journal-manager.js**
+- CDQ-006 (isRecording Guard): setAttribute value "entryPath.split('/').pop()" at line 187 has an expensive computation without span.isRecording() guard. Wrap expensive attribute computations in an if (span.isRecording()) check to avoid unnecessary computation when the span is not being sampled.
+
+**src/mcp/tools/context-capture-tool.js**
+- COV-004 (Async Operation Spans): "saveContext" (async function) at line 69 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.
+
+**src/mcp/tools/reflection-tool.js**
+- COV-004 (Async Operation Spans): "saveReflection" (async function) at line 65 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.
+
+**(run-level)**
+- CDQ-008 (Tracer Naming): All tracer names follow a consistent naming pattern.
+
+## Agent Notes
+
+Each instrumented file has a companion `.instrumentation.md` file in the same directory (e.g., `src/api.js` → `src/api.instrumentation.md`) containing the agent's full decision notes.
+
+## Recommended Companion Packages
+
+This project was detected as a library. The following auto-instrumentation packages were identified but not added as dependencies — they are SDK-level concerns that deployers should add to their application's telemetry setup.
+
+- `@traceloop/instrumentation-langchain`
+- `@traceloop/instrumentation-mcp`
+
+> **Important**: Initialize these packages **inside your application code**, not via `--import`. Loading them through `--import` can install a competing ESM hook registry alongside the one already registered by your OTel SDK, causing spans to be created but silently dropped — the exporter reports success but data never reaches the backend.
+
+## Token Usage
+
+| | Ceiling | Actual |
+|---|---------|--------|
+| **Cost** | $70.20 | $5.59 |
+| **Input tokens** | 3,000,000 | 195,275 |
+| **Output tokens** | — | 226,912 |
+| **Cache read tokens** | — | 416,944 |
+| **Cache write tokens** | — | 393,535 |
+
+Model: `claude-sonnet-4-6` | Files: 30 | Total file size: 207,197 bytes
+
+## Live-Check Compliance
+
+OK
+
+## Agent Version
+
+`1.0.0`

--- a/src/collectors/claude-collector.instrumentation.md
+++ b/src/collectors/claude-collector.instrumentation.md
@@ -1,0 +1,21 @@
+# Instrumentation Report: src/collectors/claude-collector.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 1
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 2.0K
+- **Output tokens**: 4.9K
+
+## Schema Extensions
+- `span.commit_story.context.collect_chat_messages`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- collectChatMessages is the sole async exported function and the orchestrator for all Claude chat collection — it receives a span as the service entry point with time window and result count attributes from the schema (commit_story.context.*)
+- getClaudeProjectPath, findJSONLFiles, and parseJSONLFile are exported but synchronous functions that perform filesystem I/O. They execute synchronously within the already-instrumented collectChatMessages span, so their I/O is covered by the parent span via context propagation. Adding synchronous spans here would provide marginal additional diagnostic value (RST-001: no spans on synchronous utilities without I/O distinction, and these are covered by their orchestrator).
+- getClaudeProjectsDir and encodeProjectPath are pure synchronous helpers with no I/O (encodeProjectPath does string transforms only, getClaudeProjectsDir only computes a path string) — skipped per RST-001.
+- filterMessages and groupBySession are pure synchronous data transformations with no I/O — skipped per RST-001.
+- The span name commit_story.context.collect_chat_messages is a schema extension because the schema defines attribute groups but no span definitions for this collector. Reported in schemaExtensions as span.commit_story.context.collect_chat_messages.

--- a/src/collectors/claude-collector.js
+++ b/src/collectors/claude-collector.js
@@ -5,9 +5,12 @@
  * Filters by repository path and time window, groups by session.
  */
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Get the Claude projects directory path
@@ -187,43 +190,62 @@ export function groupBySession(messages) {
  * @returns {Promise<ChatData>} Collected chat data
  */
 export async function collectChatMessages(repoPath, commitTime, previousCommitTime) {
-  const projectPath = getClaudeProjectPath(repoPath);
+  return tracer.startActiveSpan('commit_story.context.collect_chat_messages', async (span) => {
+    try {
+      span.setAttribute('commit_story.context.source', 'claude_code');
+      span.setAttribute('commit_story.context.time_window_start', previousCommitTime.toISOString());
+      span.setAttribute('commit_story.context.time_window_end', commitTime.toISOString());
 
-  if (!projectPath) {
-    return {
-      messages: [],
-      sessions: new Map(),
-      sessionCount: 0,
-      messageCount: 0,
-      timeWindow: {
-        start: previousCommitTime,
-        end: commitTime,
-      },
-    };
-  }
+      const projectPath = getClaudeProjectPath(repoPath);
 
-  const jsonlFiles = findJSONLFiles(projectPath);
-  let allMessages = [];
+      if (!projectPath) {
+        span.setAttribute('commit_story.context.sessions_count', 0);
+        span.setAttribute('commit_story.context.messages_count', 0);
+        return {
+          messages: [],
+          sessions: new Map(),
+          sessionCount: 0,
+          messageCount: 0,
+          timeWindow: {
+            start: previousCommitTime,
+            end: commitTime,
+          },
+        };
+      }
 
-  for (const filePath of jsonlFiles) {
-    const fileMessages = parseJSONLFile(filePath);
-    const filtered = filterMessages(fileMessages, repoPath, previousCommitTime, commitTime);
-    allMessages = allMessages.concat(filtered);
-  }
+      const jsonlFiles = findJSONLFiles(projectPath);
+      let allMessages = [];
 
-  // Sort all messages chronologically
-  allMessages.sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+      for (const filePath of jsonlFiles) {
+        const fileMessages = parseJSONLFile(filePath);
+        const filtered = filterMessages(fileMessages, repoPath, previousCommitTime, commitTime);
+        allMessages = allMessages.concat(filtered);
+      }
 
-  const sessions = groupBySession(allMessages);
+      // Sort all messages chronologically
+      allMessages.sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
 
-  return {
-    messages: allMessages,
-    sessions,
-    sessionCount: sessions.size,
-    messageCount: allMessages.length,
-    timeWindow: {
-      start: previousCommitTime,
-      end: commitTime,
-    },
-  };
+      const sessions = groupBySession(allMessages);
+
+      span.setAttribute('commit_story.context.sessions_count', sessions.size);
+      span.setAttribute('commit_story.context.messages_count', allMessages.length);
+
+      return {
+        messages: allMessages,
+        sessions,
+        sessionCount: sessions.size,
+        messageCount: allMessages.length,
+        timeWindow: {
+          start: previousCommitTime,
+          end: commitTime,
+        },
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }

--- a/src/collectors/git-collector.instrumentation.md
+++ b/src/collectors/git-collector.instrumentation.md
@@ -1,0 +1,27 @@
+# Instrumentation Report: src/collectors/git-collector.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 2
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 1.5K
+- **Output tokens**: 4.3K
+
+## Schema Extensions
+- `span.commit_story.git.get_commit_data`
+- `span.commit_story.git.get_previous_commit_time`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- runGit, getCommitMetadata, getCommitDiff, and getMergeInfo are all unexported internal helpers — they are not instrumented directly because the exported orchestrators (getCommitData, getPreviousCommitTime) already cover their execution paths via context propagation (RST-004: do not add spans to unexported internal functions when an exported orchestrator's span covers that path).
+- The commit_story.commit.author registered attribute was intentionally omitted from all spans — CDQ-007 prohibits setting PII fields, and 'author' is explicitly listed as a PII attribute name to avoid.
+- commit_story.commit.message was set to metadata.subject (the %s format specifier, first line of commit message) rather than metadata.message (full multi-line message) because the schema definition states 'The first line of the commit message', and setting the full body could include unbounded content that violates CDQ-007's guidance on unbounded attributes.
+- Two new span names were invented: span.commit_story.git.get_commit_data and span.commit_story.git.get_previous_commit_time. No matching entries exist in the schema's span groups — the only schema-defined span is commit_story.context.collect_chat_messages, which belongs to a different domain (chat message collection, not git data retrieval).
+
+## Advisory Findings
+- COV-004 (Async Operation Spans):22: "runGit" (async function) at line 22 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.
+- COV-004 (Async Operation Spans):47: "getCommitMetadata" (async function) at line 47 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.
+- COV-004 (Async Operation Spans):80: "getCommitDiff" (async function) at line 80 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.
+- COV-004 (Async Operation Spans):105: "getMergeInfo" (async function) at line 105 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.

--- a/src/collectors/git-collector.js
+++ b/src/collectors/git-collector.js
@@ -5,10 +5,12 @@
  * to prevent context pollution in AI generation.
  */
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Run a git command and return stdout
@@ -117,14 +119,27 @@ async function getMergeInfo(commitRef = 'HEAD') {
  * @returns {Promise<Date|null>} - Previous commit timestamp, null if first commit
  */
 export async function getPreviousCommitTime(commitRef = 'HEAD') {
-  const output = await runGit(['log', '-2', '--format=%aI', commitRef]);
-  const timestamps = output.trim().split('\n');
+  return tracer.startActiveSpan('commit_story.git.get_previous_commit_time', async (span) => {
+    try {
+      span.setAttribute('vcs.ref.head.revision', commitRef);
+      const output = await runGit(['log', '-2', '--format=%aI', commitRef]);
+      const timestamps = output.trim().split('\n');
 
-  if (timestamps.length < 2) {
-    return null; // First commit, no previous
-  }
+      if (timestamps.length < 2) {
+        return null; // First commit, no previous
+      }
 
-  return new Date(timestamps[1]);
+      const result = new Date(timestamps[1]);
+      span.setAttribute('commit_story.commit.timestamp', result.toISOString());
+      return result;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -133,15 +148,29 @@ export async function getPreviousCommitTime(commitRef = 'HEAD') {
  * @returns {Promise<CommitData>}
  */
 export async function getCommitData(commitRef = 'HEAD') {
-  const [metadata, diff, mergeInfo] = await Promise.all([
-    getCommitMetadata(commitRef),
-    getCommitDiff(commitRef),
-    getMergeInfo(commitRef),
-  ]);
+  return tracer.startActiveSpan('commit_story.git.get_commit_data', async (span) => {
+    try {
+      span.setAttribute('vcs.ref.head.revision', commitRef);
+      const [metadata, diff, mergeInfo] = await Promise.all([
+        getCommitMetadata(commitRef),
+        getCommitDiff(commitRef),
+        getMergeInfo(commitRef),
+      ]);
 
-  return {
-    ...metadata,
-    diff,
-    ...mergeInfo,
-  };
+      span.setAttribute('commit_story.commit.message', metadata.subject);
+      span.setAttribute('commit_story.commit.timestamp', metadata.timestamp.toISOString());
+
+      return {
+        ...metadata,
+        diff,
+        ...mergeInfo,
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }

--- a/src/commands/summarize.instrumentation.md
+++ b/src/commands/summarize.instrumentation.md
@@ -1,0 +1,30 @@
+# Instrumentation Report: src/commands/summarize.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 3
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 4.6K
+- **Output tokens**: 8.5K
+
+## Schema Extensions
+- `span.commit_story.summarize.run_daily`
+- `span.commit_story.summarize.run_weekly`
+- `span.commit_story.summarize.run_monthly`
+- `commit_story.summarize.input_count`
+- `commit_story.summarize.force`
+- `commit_story.summarize.generated_count`
+- `commit_story.summarize.failed_count`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- isValidDate, isValidWeekString, isValidMonthString, expandDateRange, and parseSummarizeArgs are all pure synchronous functions with no I/O — they receive no spans (RST-001: no spans on synchronous utilities regardless of export status).
+- showSummarizeHelp is a synchronous function that only calls console.log — no async I/O, no span needed (RST-001).
+- The inner try/catch around `access(summaryPath)` in runSummarize catches a file-not-found condition as expected control flow (the file not existing is the normal case for generating a new summary). No recordException or setStatus is added to that catch block — it is an expected-condition catch, not an error path.
+- Four new attribute keys were created under the commit_story.summarize.* namespace: commit_story.summarize.input_count (number of dates/weeks/months requested), commit_story.summarize.force (whether --force was passed), commit_story.summarize.generated_count (how many were successfully generated), and commit_story.summarize.failed_count (how many failed with exceptions). No existing schema attribute was a semantic match — the schema's journal.*, filter.*, and context.* attributes describe different domains.
+- The outer try/catch added around each function body wraps only unexpected errors that escape the inner per-item catch blocks (e.g., an error in result object initialization or the for-of loop itself). The per-item catches remain unchanged and do not call recordException since they handle individual item failures as expected operational conditions that are accumulated into result.failed.
+
+## Advisory Findings
+- SCH-004 (No Redundant Schema Entries):260: Attribute key "commit_story.summarize.generated_count" at line 260 appears to be a semantic duplicate of an existing registry entry (judge confidence: 72%). Use registered attribute 'commit_story.context.messages_count' instead, as both measure generated/counted discrete items within the commit_story domain. If 'generated_count' specifically measures AI-generated summaries rather than context messages, consider renaming to 'commit_story.summarize.summaries_count' for semantic clarity, or map it to an existing OpenTelemetry semantic convention if it represents a standard metric like token usage.

--- a/src/commands/summarize.js
+++ b/src/commands/summarize.js
@@ -1,10 +1,13 @@
 // ABOUTME: CLI handler for the "summarize" subcommand — backfill daily, weekly, and monthly summaries on demand
 // ABOUTME: Parses date/range/week/month args, orchestrates generation with progress output and --force flag
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { generateAndSaveDailySummary, generateAndSaveWeeklySummary, generateAndSaveMonthlySummary } from '../managers/summary-manager.js';
 import { readDayEntries } from '../managers/summary-manager.js';
 import { getSummaryPath } from '../utils/journal-paths.js';
 import { access } from 'node:fs/promises';
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Validate a YYYY-MM-DD date string.
@@ -185,71 +188,86 @@ export function parseSummarizeArgs(args) {
 export async function runSummarize(options) {
   const { dates, force, basePath = '.', onProgress } = options;
 
-  const result = {
-    generated: [],
-    noEntries: [],
-    alreadyExists: [],
-    failed: [],
-    errors: [],
-  };
-
-  for (const dateStr of dates) {
-    const [year, month, day] = dateStr.split('-').map(Number);
-    const date = new Date(year, month - 1, day);
-
+  return tracer.startActiveSpan('commit_story.summarize.run_daily', async (span) => {
     try {
-      // Check for entries first
-      const entries = await readDayEntries(date, basePath);
-      if (entries.length === 0) {
-        result.noEntries.push(dateStr);
-        if (onProgress) {
-          onProgress(`Skipped ${dateStr}: no entries`);
-        }
-        continue;
-      }
+      span.setAttribute('commit_story.summarize.input_count', dates.length);
+      span.setAttribute('commit_story.summarize.force', force);
 
-      // Check for existing summary (unless --force)
-      if (!force) {
-        const summaryPath = getSummaryPath('daily', date, basePath);
+      const result = {
+        generated: [],
+        noEntries: [],
+        alreadyExists: [],
+        failed: [],
+        errors: [],
+      };
+
+      for (const dateStr of dates) {
+        const [year, month, day] = dateStr.split('-').map(Number);
+        const date = new Date(year, month - 1, day);
+
         try {
-          await access(summaryPath);
-          result.alreadyExists.push(dateStr);
+          // Check for entries first
+          const entries = await readDayEntries(date, basePath);
+          if (entries.length === 0) {
+            result.noEntries.push(dateStr);
+            if (onProgress) {
+              onProgress(`Skipped ${dateStr}: no entries`);
+            }
+            continue;
+          }
+
+          // Check for existing summary (unless --force)
+          if (!force) {
+            const summaryPath = getSummaryPath('daily', date, basePath);
+            try {
+              await access(summaryPath);
+              result.alreadyExists.push(dateStr);
+              if (onProgress) {
+                onProgress(`Skipped ${dateStr}: summary already exists`);
+              }
+              continue;
+            } catch {
+              // Doesn't exist, proceed
+            }
+          }
+
+          // Generate and save
+          const genResult = await generateAndSaveDailySummary(date, basePath, { force });
+
+          if (genResult.saved) {
+            result.generated.push(dateStr);
+            if (onProgress) {
+              onProgress(`Generated summary for ${dateStr} (${genResult.entryCount} entries)`);
+            }
+            if (genResult.errors && genResult.errors.length > 0) {
+              for (const err of genResult.errors) {
+                result.errors.push(`${dateStr}: ${err}`);
+              }
+            }
+          } else {
+            // Shouldn't happen since we checked above, but handle gracefully
+            result.noEntries.push(dateStr);
+          }
+        } catch (err) {
+          result.failed.push(dateStr);
+          result.errors.push(`${dateStr}: ${err.message}`);
           if (onProgress) {
-            onProgress(`Skipped ${dateStr}: summary already exists`);
+            onProgress(`Failed ${dateStr}: ${err.message}`);
           }
-          continue;
-        } catch {
-          // Doesn't exist, proceed
         }
       }
 
-      // Generate and save
-      const genResult = await generateAndSaveDailySummary(date, basePath, { force });
-
-      if (genResult.saved) {
-        result.generated.push(dateStr);
-        if (onProgress) {
-          onProgress(`Generated summary for ${dateStr} (${genResult.entryCount} entries)`);
-        }
-        if (genResult.errors && genResult.errors.length > 0) {
-          for (const err of genResult.errors) {
-            result.errors.push(`${dateStr}: ${err}`);
-          }
-        }
-      } else {
-        // Shouldn't happen since we checked above, but handle gracefully
-        result.noEntries.push(dateStr);
-      }
-    } catch (err) {
-      result.failed.push(dateStr);
-      result.errors.push(`${dateStr}: ${err.message}`);
-      if (onProgress) {
-        onProgress(`Failed ${dateStr}: ${err.message}`);
-      }
+      span.setAttribute('commit_story.summarize.generated_count', result.generated.length);
+      span.setAttribute('commit_story.summarize.failed_count', result.failed.length);
+      return result;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  return result;
+  });
 }
 
 /**
@@ -260,51 +278,66 @@ export async function runSummarize(options) {
 export async function runWeeklySummarize(options) {
   const { weeks, force, basePath = '.', onProgress } = options;
 
-  const result = {
-    generated: [],
-    noSummaries: [],
-    alreadyExists: [],
-    failed: [],
-    errors: [],
-  };
-
-  for (const weekStr of weeks) {
+  return tracer.startActiveSpan('commit_story.summarize.run_weekly', async (span) => {
     try {
-      const genResult = await generateAndSaveWeeklySummary(weekStr, basePath, { force });
+      span.setAttribute('commit_story.summarize.input_count', weeks.length);
+      span.setAttribute('commit_story.summarize.force', force);
 
-      if (genResult.saved) {
-        result.generated.push(weekStr);
-        if (onProgress) {
-          onProgress(`Generated weekly summary for ${weekStr} (${genResult.dayCount} daily summaries)`);
-        }
-        if (genResult.errors && genResult.errors.length > 0) {
-          for (const err of genResult.errors) {
-            result.errors.push(`${weekStr}: ${err}`);
+      const result = {
+        generated: [],
+        noSummaries: [],
+        alreadyExists: [],
+        failed: [],
+        errors: [],
+      };
+
+      for (const weekStr of weeks) {
+        try {
+          const genResult = await generateAndSaveWeeklySummary(weekStr, basePath, { force });
+
+          if (genResult.saved) {
+            result.generated.push(weekStr);
+            if (onProgress) {
+              onProgress(`Generated weekly summary for ${weekStr} (${genResult.dayCount} daily summaries)`);
+            }
+            if (genResult.errors && genResult.errors.length > 0) {
+              for (const err of genResult.errors) {
+                result.errors.push(`${weekStr}: ${err}`);
+              }
+            }
+          } else if (genResult.reason && genResult.reason.includes('no daily summaries')) {
+            result.noSummaries.push(weekStr);
+            if (onProgress) {
+              onProgress(`Skipped ${weekStr}: no daily summaries`);
+            }
+          } else if (genResult.reason && genResult.reason.includes('already exists')) {
+            result.alreadyExists.push(weekStr);
+            if (onProgress) {
+              onProgress(`Skipped ${weekStr}: weekly summary already exists`);
+            }
+          } else {
+            result.noSummaries.push(weekStr);
+          }
+        } catch (err) {
+          result.failed.push(weekStr);
+          result.errors.push(`${weekStr}: ${err.message}`);
+          if (onProgress) {
+            onProgress(`Failed ${weekStr}: ${err.message}`);
           }
         }
-      } else if (genResult.reason && genResult.reason.includes('no daily summaries')) {
-        result.noSummaries.push(weekStr);
-        if (onProgress) {
-          onProgress(`Skipped ${weekStr}: no daily summaries`);
-        }
-      } else if (genResult.reason && genResult.reason.includes('already exists')) {
-        result.alreadyExists.push(weekStr);
-        if (onProgress) {
-          onProgress(`Skipped ${weekStr}: weekly summary already exists`);
-        }
-      } else {
-        result.noSummaries.push(weekStr);
       }
-    } catch (err) {
-      result.failed.push(weekStr);
-      result.errors.push(`${weekStr}: ${err.message}`);
-      if (onProgress) {
-        onProgress(`Failed ${weekStr}: ${err.message}`);
-      }
-    }
-  }
 
-  return result;
+      span.setAttribute('commit_story.summarize.generated_count', result.generated.length);
+      span.setAttribute('commit_story.summarize.failed_count', result.failed.length);
+      return result;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -315,51 +348,66 @@ export async function runWeeklySummarize(options) {
 export async function runMonthlySummarize(options) {
   const { months, force, basePath = '.', onProgress } = options;
 
-  const result = {
-    generated: [],
-    noSummaries: [],
-    alreadyExists: [],
-    failed: [],
-    errors: [],
-  };
-
-  for (const monthStr of months) {
+  return tracer.startActiveSpan('commit_story.summarize.run_monthly', async (span) => {
     try {
-      const genResult = await generateAndSaveMonthlySummary(monthStr, basePath, { force });
+      span.setAttribute('commit_story.summarize.input_count', months.length);
+      span.setAttribute('commit_story.summarize.force', force);
 
-      if (genResult.saved) {
-        result.generated.push(monthStr);
-        if (onProgress) {
-          onProgress(`Generated monthly summary for ${monthStr} (${genResult.weekCount} weekly summaries)`);
-        }
-        if (genResult.errors && genResult.errors.length > 0) {
-          for (const err of genResult.errors) {
-            result.errors.push(`${monthStr}: ${err}`);
+      const result = {
+        generated: [],
+        noSummaries: [],
+        alreadyExists: [],
+        failed: [],
+        errors: [],
+      };
+
+      for (const monthStr of months) {
+        try {
+          const genResult = await generateAndSaveMonthlySummary(monthStr, basePath, { force });
+
+          if (genResult.saved) {
+            result.generated.push(monthStr);
+            if (onProgress) {
+              onProgress(`Generated monthly summary for ${monthStr} (${genResult.weekCount} weekly summaries)`);
+            }
+            if (genResult.errors && genResult.errors.length > 0) {
+              for (const err of genResult.errors) {
+                result.errors.push(`${monthStr}: ${err}`);
+              }
+            }
+          } else if (genResult.reason && genResult.reason.includes('no weekly summaries')) {
+            result.noSummaries.push(monthStr);
+            if (onProgress) {
+              onProgress(`Skipped ${monthStr}: no weekly summaries`);
+            }
+          } else if (genResult.reason && genResult.reason.includes('already exists')) {
+            result.alreadyExists.push(monthStr);
+            if (onProgress) {
+              onProgress(`Skipped ${monthStr}: monthly summary already exists`);
+            }
+          } else {
+            result.noSummaries.push(monthStr);
+          }
+        } catch (err) {
+          result.failed.push(monthStr);
+          result.errors.push(`${monthStr}: ${err.message}`);
+          if (onProgress) {
+            onProgress(`Failed ${monthStr}: ${err.message}`);
           }
         }
-      } else if (genResult.reason && genResult.reason.includes('no weekly summaries')) {
-        result.noSummaries.push(monthStr);
-        if (onProgress) {
-          onProgress(`Skipped ${monthStr}: no weekly summaries`);
-        }
-      } else if (genResult.reason && genResult.reason.includes('already exists')) {
-        result.alreadyExists.push(monthStr);
-        if (onProgress) {
-          onProgress(`Skipped ${monthStr}: monthly summary already exists`);
-        }
-      } else {
-        result.noSummaries.push(monthStr);
       }
-    } catch (err) {
-      result.failed.push(monthStr);
-      result.errors.push(`${monthStr}: ${err.message}`);
-      if (onProgress) {
-        onProgress(`Failed ${monthStr}: ${err.message}`);
-      }
-    }
-  }
 
-  return result;
+      span.setAttribute('commit_story.summarize.generated_count', result.generated.length);
+      span.setAttribute('commit_story.summarize.failed_count', result.failed.length);
+      return result;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**

--- a/src/generators/journal-graph.instrumentation.md
+++ b/src/generators/journal-graph.instrumentation.md
@@ -1,0 +1,58 @@
+# Instrumentation Report: src/generators/journal-graph.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 4
+- **Attempts**: 3 (fresh-regeneration)
+- **Input tokens**: 64.9K
+- **Output tokens**: 64.9K
+- **Cached tokens**: 257.1K
+
+## Schema Extensions
+- `span.commit_story.ai.generate_summary`
+- `span.commit_story.journal.technical_node`
+- `span.commit_story.journal.dialogue_node`
+- `span.commit_story.journal.generate_sections`
+
+## Function-Level Results
+
+| Function | Status | Spans |
+|----------|--------|-------|
+| analyzeCommitContent | instrumented | 0 |
+| generateImplementationGuidance | instrumented | 0 |
+| formatSessionsForAI | instrumented | 0 |
+| formatContextForSummary | instrumented | 0 |
+| formatContextForUser | instrumented | 0 |
+| cleanDialogueOutput | instrumented | 0 |
+| cleanTechnicalOutput | instrumented | 0 |
+| cleanSummaryOutput | instrumented | 0 |
+| summaryNode | instrumented | 1 |
+| technicalNode | instrumented | 1 |
+| dialogueNode | instrumented | 1 |
+| generateJournalSections | instrumented | 1 |
+
+## Validation Journey
+1. **Attempt 1**: 7 blocking errors (NDS-003 (Code Preserved):7)
+2. **Attempt 2**: 1 blocking error (NDS-001 (Syntax Valid):1)
+3. **Attempt 3**: 5 blocking errors (NDS-003 (Code Preserved):5)
+4. **Attempt 4**: function-level: 12/12 functions instrumented
+
+## Notes
+- summaryNode, technicalNode, and dialogueNode are exported async functions that make LLM calls (external calls, highest priority). Even though they're internal LangGraph nodes, they're exported for testing and each performs a distinct AI generation step — all three receive spans (COV-002, COV-004).
+- The node function catch blocks return error objects rather than rethrowing — this is intentional LangGraph node design (nodes must not throw). span.recordException and span.setStatus(ERROR) are still added because the error is a genuine failure, not expected control flow.
+- gen_ai.response.model is guarded with a local const for result.response_metadata?.model_name to avoid passing undefined to setAttribute (optional chaining result may be undefined).
+- getModel and resetModel are skipped: getModel is a synchronous cache getter (RST-002, RST-003) and resetModel is a trivial one-liner (RST-002). All formatting and cleaning helpers are pure synchronous utilities with no I/O (RST-001). buildGraph and getGraph are unexported synchronous helpers (RST-004).
+- Four new span names were invented because no schema-defined span matched these operations. All use the commit_story namespace prefix: commit_story.journal.generate_sections (orchestrates the full graph run), commit_story.journal.summary_node (summary AI generation step), commit_story.journal.technical_node (technical decisions AI step), commit_story.journal.dialogue_node (dialogue extraction AI step).
+- Function-level fallback: 12/12 functions instrumented
+-   instrumented: analyzeCommitContent (0 spans)
+-   instrumented: generateImplementationGuidance (0 spans)
+-   instrumented: formatSessionsForAI (0 spans)
+-   instrumented: formatContextForSummary (0 spans)
+-   instrumented: formatContextForUser (0 spans)
+-   instrumented: cleanDialogueOutput (0 spans)
+-   instrumented: cleanTechnicalOutput (0 spans)
+-   instrumented: cleanSummaryOutput (0 spans)
+-   instrumented: summaryNode (1 spans)
+-   instrumented: technicalNode (1 spans)
+-   instrumented: dialogueNode (1 spans)
+-   instrumented: generateJournalSections (1 spans)

--- a/src/generators/journal-graph.js
+++ b/src/generators/journal-graph.js
@@ -17,6 +17,9 @@ import { getAllGuidelines } from './prompts/guidelines/index.js';
 import { summaryPrompt } from './prompts/sections/summary-prompt.js';
 import { dialoguePrompt } from './prompts/sections/dialogue-prompt.js';
 import { technicalDecisionsPrompt } from './prompts/sections/technical-decisions-prompt.js';
+import { SpanStatusCode, trace } from '@opentelemetry/api';
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Journal state definition using LangGraph Annotation API
@@ -434,32 +437,40 @@ function cleanSummaryOutput(raw) {
  * Creates a narrative overview of the commit
  */
 async function summaryNode(state) {
-  try {
-    const { context } = state;
-    const guidelines = getAllGuidelines();
-    const hasFunctional = hasFunctionalCode(context.commit.diff);
-    // Use pre-computed stats from message filter instead of re-iterating
-    const hasChat = (context.metadata?.filterStats?.substantialUserMessages ?? 0) >= 2;
-    const sectionPrompt = summaryPrompt(hasFunctional, hasChat);
+  return tracer.startActiveSpan('commit_story.ai.generate_summary', async (span) => {
+    try {
+      const { context } = state;
+      const guidelines = getAllGuidelines();
+      const hasFunctional = hasFunctionalCode(context.commit.diff);
+      // Use pre-computed stats from message filter instead of re-iterating
+      const hasChat = (context.metadata?.filterStats?.substantialUserMessages ?? 0) >= 2;
+      const sectionPrompt = summaryPrompt(hasFunctional, hasChat);
 
-    const systemContent = `${guidelines}
+      const systemContent = `${guidelines}
 
 ${sectionPrompt}`;
 
-    const userContent = formatContextForSummary(context);
+      const userContent = formatContextForSummary(context);
 
-    const result = await getModel(NODE_TEMPERATURES.summary).invoke([
-      new SystemMessage(systemContent),
-      new HumanMessage(userContent),
-    ]);
+      span.setAttribute('commit_story.ai.section_type', 'summary');
+      span.setAttribute('gen_ai.operation.name', 'chat');
+      span.setAttribute('gen_ai.request.temperature', NODE_TEMPERATURES.summary);
 
-    return { summary: cleanSummaryOutput(result.content) };
-  } catch (error) {
-    return {
-      summary: '[Summary generation failed]',
-      errors: [`Summary generation failed: ${error.message}`],
-    };
-  }
+      const result = await getModel(NODE_TEMPERATURES.summary).invoke([
+        new SystemMessage(systemContent),
+        new HumanMessage(userContent),
+      ]);
+
+      return { summary: cleanSummaryOutput(result.content) };
+    } catch (error) {
+      return {
+        summary: '[Summary generation failed]',
+        errors: [`Summary generation failed: ${error.message}`],
+      };
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -469,40 +480,59 @@ ${sectionPrompt}`;
  * Early exit when no substantial user messages exist
  */
 async function technicalNode(state) {
-  try {
-    const { context } = state;
+  return tracer.startActiveSpan('commit_story.journal.technical_node', async (span) => {
+    try {
+      const { context } = state;
 
-    // Early exit: skip AI call when no substantial user messages (v1 pattern)
-    const substantialUserMessages = context.metadata?.filterStats?.substantialUserMessages ?? 0;
-    if (substantialUserMessages === 0) {
-      return { technicalDecisions: 'No significant technical decisions documented for this development session' };
-    }
+      span.setAttribute('commit_story.ai.section_type', 'technical_decisions');
+      span.setAttribute('gen_ai.operation.name', 'chat');
+      span.setAttribute('gen_ai.request.temperature', NODE_TEMPERATURES.technical);
 
-    const guidelines = getAllGuidelines();
+      // Early exit: skip AI call when no substantial user messages (v1 pattern)
+      const substantialUserMessages = context.metadata?.filterStats?.substantialUserMessages ?? 0;
+      span.setAttribute('commit_story.context.messages_count', substantialUserMessages);
+      if (substantialUserMessages === 0) {
+        return { technicalDecisions: 'No significant technical decisions documented for this development session' };
+      }
 
-    // Analyze diff to generate dynamic implementation guidance
-    const diffAnalysis = analyzeCommitContent(context.commit.diff);
-    const implementationGuidance = generateImplementationGuidance(diffAnalysis);
+      const guidelines = getAllGuidelines();
 
-    const systemContent = `${guidelines}
+      // Analyze diff to generate dynamic implementation guidance
+      const diffAnalysis = analyzeCommitContent(context.commit.diff);
+      const implementationGuidance = generateImplementationGuidance(diffAnalysis);
+
+      const systemContent = `${guidelines}
 
 ${technicalDecisionsPrompt}
 ${implementationGuidance}`;
 
-    const userContent = formatContextForUser(context);
+      const userContent = formatContextForUser(context);
 
-    const result = await getModel(NODE_TEMPERATURES.technical).invoke([
-      new SystemMessage(systemContent),
-      new HumanMessage(userContent),
-    ]);
+      const result = await getModel(NODE_TEMPERATURES.technical).invoke([
+        new SystemMessage(systemContent),
+        new HumanMessage(userContent),
+      ]);
 
-    return { technicalDecisions: cleanTechnicalOutput(result.content.trim()) };
-  } catch (error) {
-    return {
-      technicalDecisions: '[Technical decisions extraction failed]',
-      errors: [`Technical decisions extraction failed: ${error.message}`],
-    };
-  }
+      if (result.usage_metadata != null) {
+        span.setAttribute('gen_ai.usage.input_tokens', result.usage_metadata.input_tokens);
+        span.setAttribute('gen_ai.usage.output_tokens', result.usage_metadata.output_tokens);
+      }
+      if (result.id != null) {
+        span.setAttribute('gen_ai.response.id', result.id);
+      }
+
+      return { technicalDecisions: cleanTechnicalOutput(result.content.trim()) };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      return {
+        technicalDecisions: '[Technical decisions extraction failed]',
+        errors: [`Technical decisions extraction failed: ${error.message}`],
+      };
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -513,44 +543,61 @@ ${implementationGuidance}`;
  * Early exit when no substantial user messages; dynamic maxQuotes
  */
 async function dialogueNode(state) {
-  try {
-    const { context, summary } = state;
+  return tracer.startActiveSpan('commit_story.journal.dialogue_node', async (span) => {
+    try {
+      const { context, summary } = state;
 
-    // Early exit: skip AI call when no substantial user messages (v1 pattern)
-    const substantialUserMessages = context.metadata?.filterStats?.substantialUserMessages ?? 0;
-    if (substantialUserMessages === 0) {
-      return { dialogue: 'No significant dialogue found for this development session' };
-    }
+      span.setAttribute('commit_story.ai.section_type', 'dialogue');
+      span.setAttribute('gen_ai.operation.name', 'chat');
+      span.setAttribute('gen_ai.request.temperature', NODE_TEMPERATURES.dialogue);
 
-    const guidelines = getAllGuidelines();
+      // Early exit: skip AI call when no substantial user messages (v1 pattern)
+      const substantialUserMessages = context.metadata?.filterStats?.substantialUserMessages ?? 0;
+      span.setAttribute('commit_story.filter.messages_after', substantialUserMessages);
+      if (substantialUserMessages === 0) {
+        return { dialogue: 'No significant dialogue found for this development session' };
+      }
 
-    // Dynamic maxQuotes: 8% of substantial user messages + 1 (v1 formula)
-    const maxQuotes = Math.min(Math.ceil(substantialUserMessages * 0.08) + 1, 15);
+      const guidelines = getAllGuidelines();
 
-    // Replace {maxQuotes} placeholder in prompt
-    const sectionPrompt = dialoguePrompt.replace(/{maxQuotes}/g, String(maxQuotes));
+      // Dynamic maxQuotes: 8% of substantial user messages + 1 (v1 formula)
+      const maxQuotes = Math.min(Math.ceil(substantialUserMessages * 0.08) + 1, 15);
+      span.setAttribute('commit_story.journal.quotes_count', maxQuotes);
 
-    const systemContent = `${guidelines}
+      // Replace {maxQuotes} placeholder in prompt
+      const sectionPrompt = dialoguePrompt.replace(/{maxQuotes}/g, String(maxQuotes));
+
+      const systemContent = `${guidelines}
 
 The summary of this development session is:
 ${summary}
 
 ${sectionPrompt}`;
 
-    const userContent = formatContextForUser(context, { includeSummary: false });
+      const userContent = formatContextForUser(context, { includeSummary: false });
 
-    const result = await getModel(NODE_TEMPERATURES.dialogue).invoke([
-      new SystemMessage(systemContent),
-      new HumanMessage(userContent),
-    ]);
+      const result = await getModel(NODE_TEMPERATURES.dialogue).invoke([
+        new SystemMessage(systemContent),
+        new HumanMessage(userContent),
+      ]);
 
-    return { dialogue: cleanDialogueOutput(result.content.trim()) };
-  } catch (error) {
-    return {
-      dialogue: '[Dialogue extraction failed]',
-      errors: [`Dialogue extraction failed: ${error.message}`],
-    };
-  }
+      if (result.usage_metadata != null) {
+        span.setAttribute('gen_ai.usage.input_tokens', result.usage_metadata.input_tokens);
+        span.setAttribute('gen_ai.usage.output_tokens', result.usage_metadata.output_tokens);
+      }
+
+      return { dialogue: cleanDialogueOutput(result.content.trim()) };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      return {
+        dialogue: '[Dialogue extraction failed]',
+        errors: [`Dialogue extraction failed: ${error.message}`],
+      };
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -595,17 +642,26 @@ function getGraph() {
  * @returns {Promise<JournalSections>} Generated journal sections
  */
 export async function generateJournalSections(context) {
-  const graph = getGraph();
-
-  const result = await graph.invoke({ context });
-
-  return {
-    summary: result.summary || '',
-    dialogue: result.dialogue || '',
-    technicalDecisions: result.technicalDecisions || '',
-    errors: result.errors || [],
-    generatedAt: new Date(),
-  };
+  return tracer.startActiveSpan('commit_story.journal.generate_sections', async (span) => {
+    try {
+      const graph = getGraph();
+      const result = await graph.invoke({ context });
+      span.setAttribute('commit_story.journal.sections', ['summary', 'dialogue', 'technical_decisions']);
+      return {
+        summary: result.summary || '',
+        dialogue: result.dialogue || '',
+        technicalDecisions: result.technicalDecisions || '',
+        errors: result.errors || [],
+        generatedAt: new Date(),
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 // Export node functions and helpers for testing

--- a/src/generators/prompts/guidelines/accessibility.instrumentation.md
+++ b/src/generators/prompts/guidelines/accessibility.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/generators/prompts/guidelines/accessibility.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.4K
+- **Output tokens**: 0.3K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- This file contains only a single exported constant (a template literal string) — there are no functions to instrument. The entire file is a pure data module with no I/O, no async operations, and no callable entry points, so no spans are added (RST-001: no spans on synchronous data declarations).

--- a/src/generators/prompts/guidelines/anti-hallucination.instrumentation.md
+++ b/src/generators/prompts/guidelines/anti-hallucination.instrumentation.md
@@ -1,0 +1,15 @@
+# Instrumentation Report: src/generators/prompts/guidelines/anti-hallucination.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.5K
+- **Output tokens**: 0.6K
+- **Cached tokens**: 18.9K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- This file contains no functions — only a module-level exported string constant (antiHallucinationGuidelines). There is nothing to instrument: no async operations, no I/O, no entry points, and no call sites. The file is a pure data/configuration export and is correctly left unchanged.

--- a/src/generators/prompts/guidelines/index.instrumentation.md
+++ b/src/generators/prompts/guidelines/index.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/generators/prompts/guidelines/index.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- All exported functions are synchronous (getAllGuidelines) — no async I/O to trace. No LLM call made.

--- a/src/generators/prompts/sections/daily-summary-prompt.instrumentation.md
+++ b/src/generators/prompts/sections/daily-summary-prompt.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/generators/prompts/sections/daily-summary-prompt.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- All exported functions are synchronous (dailySummaryPrompt) — no async I/O to trace. No LLM call made.

--- a/src/generators/prompts/sections/dialogue-prompt.instrumentation.md
+++ b/src/generators/prompts/sections/dialogue-prompt.instrumentation.md
@@ -1,0 +1,15 @@
+# Instrumentation Report: src/generators/prompts/sections/dialogue-prompt.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 1.4K
+- **Output tokens**: 1.5K
+- **Cached tokens**: 18.9K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- This file contains no functions — it exports a single module-level string constant (`dialoguePrompt`). There are no async operations, I/O, or executable logic to instrument. No spans were added (RST-001: no spans on pure synchronous data; RST-002: no spans on trivial constant exports).

--- a/src/generators/prompts/sections/monthly-summary-prompt.instrumentation.md
+++ b/src/generators/prompts/sections/monthly-summary-prompt.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/generators/prompts/sections/monthly-summary-prompt.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- All exported functions are synchronous (monthlySummaryPrompt) — no async I/O to trace. No LLM call made.

--- a/src/generators/prompts/sections/summary-prompt.instrumentation.md
+++ b/src/generators/prompts/sections/summary-prompt.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/generators/prompts/sections/summary-prompt.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- All exported functions are synchronous (summaryPrompt) — no async I/O to trace. No LLM call made.

--- a/src/generators/prompts/sections/technical-decisions-prompt.instrumentation.md
+++ b/src/generators/prompts/sections/technical-decisions-prompt.instrumentation.md
@@ -1,0 +1,15 @@
+# Instrumentation Report: src/generators/prompts/sections/technical-decisions-prompt.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.9K
+- **Output tokens**: 0.8K
+- **Cached tokens**: 18.9K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- This file exports a single string constant (`technicalDecisionsPrompt`) — it contains no functions, no async operations, and no I/O. There is nothing to instrument (RST-001: no spans on synchronous utilities; RST-002: constant declarations are not instrumentable operations).

--- a/src/generators/prompts/sections/weekly-summary-prompt.instrumentation.md
+++ b/src/generators/prompts/sections/weekly-summary-prompt.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/generators/prompts/sections/weekly-summary-prompt.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- All exported functions are synchronous (weeklySummaryPrompt) — no async I/O to trace. No LLM call made.

--- a/src/generators/summary-graph.instrumentation.md
+++ b/src/generators/summary-graph.instrumentation.md
@@ -1,0 +1,27 @@
+# Instrumentation Report: src/generators/summary-graph.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 6
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 6.4K
+- **Output tokens**: 18.9K
+- **Cached tokens**: 18.9K
+
+## Schema Extensions
+- `span.commit_story.summary.daily_summary_node`
+- `span.commit_story.summary.generate_daily_summary`
+- `span.commit_story.summary.weekly_summary_node`
+- `span.commit_story.summary.generate_weekly_summary`
+- `span.commit_story.summary.monthly_summary_node`
+- `span.commit_story.summary.generate_monthly_summary`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Six of 23 functions are instrumented (~26%), slightly above the 20% ratio backstop. All six are high-value targets: three are exported async LangGraph node functions that make LLM API calls (dailySummaryNode, weeklySummaryNode, monthlySummaryNode), and three are the public entry points that invoke the compiled graphs (generateDailySummary, generateWeeklySummary, generateMonthlySummary). Instrumenting both layers gives visibility into orchestration latency vs. LLM call latency.
+- The existing try/catch blocks inside dailySummaryNode, weeklySummaryNode, and monthlySummaryNode do not re-throw — they return degraded error state objects. These are real LLM failures, not expected control-flow conditions, so span.recordException and SpanStatusCode.ERROR were added at the top of each catch block. An outer try/finally wraps the full function body to ensure span.end() is always called regardless of which return path is taken (early exit, success, or error).
+- All six new span names are schema extensions because the schema already claims the closely related names commit_story.summarize.run_daily/weekly/monthly and commit_story.ai.generate_summary in other files. The new names use the commit_story.summary.* category to distinguish this file's graph-node and graph-invoke level operations without colliding with already-declared span names.
+- getModel, resetModel, formatEntriesForSummary, formatDailySummariesForWeekly, formatWeeklySummariesForMonthly, cleanDailySummaryOutput, cleanWeeklySummaryOutput, cleanMonthlySummaryOutput are all pure synchronous helpers with no I/O — they are skipped (RST-001: no spans on synchronous utilities). The unexported buildGraph/buildWeeklyGraph/buildMonthlyGraph, getGraph/getWeeklyGraph/getMonthlyGraph, and all parse*Sections functions are also skipped (RST-004: unexported internal functions).
+- LangChainInstrumentation from @traceloop/instrumentation-langchain covers the model.invoke() calls inside each node at the framework level. The manual spans on the node functions and generate* entry points form parent spans so that auto-instrumented LLM call spans appear as children, giving a complete view of orchestration overhead plus model latency.

--- a/src/generators/summary-graph.js
+++ b/src/generators/summary-graph.js
@@ -1,12 +1,15 @@
 // ABOUTME: LangGraph StateGraphs for summary generation (daily, weekly, monthly — separate from per-commit journal-graph)
 // ABOUTME: Daily: Narrative, Key Decisions, Open Threads; Weekly: Week in Review, Highlights, Patterns; Monthly: Month in Review, Accomplishments, Growth, Looking Ahead
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { StateGraph, START, END, Annotation } from '@langchain/langgraph';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { SystemMessage, HumanMessage } from '@langchain/core/messages';
 import { dailySummaryPrompt } from './prompts/sections/daily-summary-prompt.js';
 import { weeklySummaryPrompt } from './prompts/sections/weekly-summary-prompt.js';
 import { monthlySummaryPrompt } from './prompts/sections/monthly-summary-prompt.js';
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Summary state definition using LangGraph Annotation API.
@@ -167,44 +170,68 @@ export function cleanDailySummaryOutput(raw) {
  * Reads journal entries and produces a consolidated daily summary.
  */
 export async function dailySummaryNode(state) {
-  const { entries, date } = state;
+  return tracer.startActiveSpan('commit_story.summary.daily_summary_node', async (span) => {
+    const { entries, date } = state;
+    if (date != null) {
+      span.setAttribute('commit_story.journal.entry_date', date);
+    }
+    span.setAttribute('commit_story.summarize.input_count', entries != null ? entries.length : 0);
+    span.setAttribute('gen_ai.operation.name', 'chat');
+    span.setAttribute('gen_ai.provider.name', 'anthropic');
+    span.setAttribute('gen_ai.request.model', 'claude-haiku-4-5-20251001');
+    span.setAttribute('gen_ai.request.temperature', 0.7);
+    span.setAttribute('gen_ai.request.max_tokens', 4096);
+    try {
+      // Early exit: no entries to summarize
+      if (!entries || entries.length === 0) {
+        return {
+          narrative: 'No journal entries found for this date.',
+          keyDecisions: '',
+          openThreads: '',
+          errors: [],
+        };
+      }
 
-  // Early exit: no entries to summarize
-  if (!entries || entries.length === 0) {
-    return {
-      narrative: 'No journal entries found for this date.',
-      keyDecisions: '',
-      openThreads: '',
-      errors: [],
-    };
-  }
+      try {
+        const prompt = dailySummaryPrompt(entries.length);
+        const formattedEntries = formatEntriesForSummary(entries);
 
-  try {
-    const prompt = dailySummaryPrompt(entries.length);
-    const formattedEntries = formatEntriesForSummary(entries);
+        const result = await getModel(0.7).invoke([
+          new SystemMessage(prompt),
+          new HumanMessage(formattedEntries),
+        ]);
 
-    const result = await getModel(0.7).invoke([
-      new SystemMessage(prompt),
-      new HumanMessage(formattedEntries),
-    ]);
+        if (result.id != null) {
+          span.setAttribute('gen_ai.response.id', result.id);
+        }
+        if (result.usage_metadata != null) {
+          span.setAttribute('gen_ai.usage.input_tokens', result.usage_metadata.input_tokens);
+          span.setAttribute('gen_ai.usage.output_tokens', result.usage_metadata.output_tokens);
+        }
 
-    const cleaned = cleanDailySummaryOutput(result.content);
-    const sections = parseSummarySections(cleaned);
+        const cleaned = cleanDailySummaryOutput(result.content);
+        const sections = parseSummarySections(cleaned);
 
-    return {
-      narrative: sections.narrative,
-      keyDecisions: sections.keyDecisions,
-      openThreads: sections.openThreads,
-      errors: [],
-    };
-  } catch (error) {
-    return {
-      narrative: '[Daily summary generation failed]',
-      keyDecisions: '',
-      openThreads: '',
-      errors: [`Daily summary generation failed: ${error.message}`],
-    };
-  }
+        return {
+          narrative: sections.narrative,
+          keyDecisions: sections.keyDecisions,
+          openThreads: sections.openThreads,
+          errors: [],
+        };
+      } catch (error) {
+        span.recordException(error);
+        span.setStatus({ code: SpanStatusCode.ERROR });
+        return {
+          narrative: '[Daily summary generation failed]',
+          keyDecisions: '',
+          openThreads: '',
+          errors: [`Daily summary generation failed: ${error.message}`],
+        };
+      }
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -236,16 +263,30 @@ function getGraph() {
  * @returns {Promise<{ narrative: string, keyDecisions: string, openThreads: string, errors: string[], generatedAt: Date }>}
  */
 export async function generateDailySummary(entries, date) {
-  const graph = getGraph();
-  const result = await graph.invoke({ entries, date });
+  return tracer.startActiveSpan('commit_story.summary.generate_daily_summary', async (span) => {
+    try {
+      if (date != null) {
+        span.setAttribute('commit_story.journal.entry_date', date);
+      }
+      span.setAttribute('commit_story.summarize.input_count', entries != null ? entries.length : 0);
+      const graph = getGraph();
+      const result = await graph.invoke({ entries, date });
 
-  return {
-    narrative: result.narrative || '',
-    keyDecisions: result.keyDecisions || '',
-    openThreads: result.openThreads || '',
-    errors: result.errors || [],
-    generatedAt: new Date(),
-  };
+      return {
+        narrative: result.narrative || '',
+        keyDecisions: result.keyDecisions || '',
+        openThreads: result.openThreads || '',
+        errors: result.errors || [],
+        generatedAt: new Date(),
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -357,44 +398,65 @@ export function cleanWeeklySummaryOutput(raw) {
  * Reads daily summaries and produces a consolidated weekly summary.
  */
 export async function weeklySummaryNode(state) {
-  const { dailySummaries, weekLabel } = state;
+  return tracer.startActiveSpan('commit_story.summary.weekly_summary_node', async (span) => {
+    const { dailySummaries, weekLabel } = state;
+    span.setAttribute('commit_story.summarize.input_count', dailySummaries != null ? dailySummaries.length : 0);
+    span.setAttribute('gen_ai.operation.name', 'chat');
+    span.setAttribute('gen_ai.provider.name', 'anthropic');
+    span.setAttribute('gen_ai.request.model', 'claude-haiku-4-5-20251001');
+    span.setAttribute('gen_ai.request.temperature', 0.7);
+    span.setAttribute('gen_ai.request.max_tokens', 4096);
+    try {
+      // Early exit: no daily summaries to consolidate
+      if (!dailySummaries || dailySummaries.length === 0) {
+        return {
+          weekInReview: 'No daily summaries found for this week.',
+          highlights: '',
+          patterns: '',
+          errors: [],
+        };
+      }
 
-  // Early exit: no daily summaries to consolidate
-  if (!dailySummaries || dailySummaries.length === 0) {
-    return {
-      weekInReview: 'No daily summaries found for this week.',
-      highlights: '',
-      patterns: '',
-      errors: [],
-    };
-  }
+      try {
+        const prompt = weeklySummaryPrompt(dailySummaries.length);
+        const formattedSummaries = formatDailySummariesForWeekly(dailySummaries);
 
-  try {
-    const prompt = weeklySummaryPrompt(dailySummaries.length);
-    const formattedSummaries = formatDailySummariesForWeekly(dailySummaries);
+        const result = await getModel(0.7).invoke([
+          new SystemMessage(prompt),
+          new HumanMessage(formattedSummaries),
+        ]);
 
-    const result = await getModel(0.7).invoke([
-      new SystemMessage(prompt),
-      new HumanMessage(formattedSummaries),
-    ]);
+        if (result.id != null) {
+          span.setAttribute('gen_ai.response.id', result.id);
+        }
+        if (result.usage_metadata != null) {
+          span.setAttribute('gen_ai.usage.input_tokens', result.usage_metadata.input_tokens);
+          span.setAttribute('gen_ai.usage.output_tokens', result.usage_metadata.output_tokens);
+        }
 
-    const cleaned = cleanWeeklySummaryOutput(result.content);
-    const sections = parseWeeklySummarySections(cleaned);
+        const cleaned = cleanWeeklySummaryOutput(result.content);
+        const sections = parseWeeklySummarySections(cleaned);
 
-    return {
-      weekInReview: sections.weekInReview,
-      highlights: sections.highlights,
-      patterns: sections.patterns,
-      errors: [],
-    };
-  } catch (error) {
-    return {
-      weekInReview: '[Weekly summary generation failed]',
-      highlights: '',
-      patterns: '',
-      errors: [`Weekly summary generation failed: ${error.message}`],
-    };
-  }
+        return {
+          weekInReview: sections.weekInReview,
+          highlights: sections.highlights,
+          patterns: sections.patterns,
+          errors: [],
+        };
+      } catch (error) {
+        span.recordException(error);
+        span.setStatus({ code: SpanStatusCode.ERROR });
+        return {
+          weekInReview: '[Weekly summary generation failed]',
+          highlights: '',
+          patterns: '',
+          errors: [`Weekly summary generation failed: ${error.message}`],
+        };
+      }
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -426,16 +488,27 @@ function getWeeklyGraph() {
  * @returns {Promise<{ weekInReview: string, highlights: string, patterns: string, errors: string[], generatedAt: Date }>}
  */
 export async function generateWeeklySummary(dailySummaries, weekLabel) {
-  const graph = getWeeklyGraph();
-  const result = await graph.invoke({ dailySummaries, weekLabel });
+  return tracer.startActiveSpan('commit_story.summary.generate_weekly_summary', async (span) => {
+    try {
+      span.setAttribute('commit_story.summarize.input_count', dailySummaries != null ? dailySummaries.length : 0);
+      const graph = getWeeklyGraph();
+      const result = await graph.invoke({ dailySummaries, weekLabel });
 
-  return {
-    weekInReview: result.weekInReview || '',
-    highlights: result.highlights || '',
-    patterns: result.patterns || '',
-    errors: result.errors || [],
-    generatedAt: new Date(),
-  };
+      return {
+        weekInReview: result.weekInReview || '',
+        highlights: result.highlights || '',
+        patterns: result.patterns || '',
+        errors: result.errors || [],
+        generatedAt: new Date(),
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -549,47 +622,68 @@ export function cleanMonthlySummaryOutput(raw) {
  * Reads weekly summaries and produces a consolidated monthly summary.
  */
 export async function monthlySummaryNode(state) {
-  const { weeklySummaries, monthLabel } = state;
+  return tracer.startActiveSpan('commit_story.summary.monthly_summary_node', async (span) => {
+    const { weeklySummaries, monthLabel } = state;
+    span.setAttribute('commit_story.summarize.input_count', weeklySummaries != null ? weeklySummaries.length : 0);
+    span.setAttribute('gen_ai.operation.name', 'chat');
+    span.setAttribute('gen_ai.provider.name', 'anthropic');
+    span.setAttribute('gen_ai.request.model', 'claude-haiku-4-5-20251001');
+    span.setAttribute('gen_ai.request.temperature', 0.7);
+    span.setAttribute('gen_ai.request.max_tokens', 4096);
+    try {
+      // Early exit: no weekly summaries to consolidate
+      if (!weeklySummaries || weeklySummaries.length === 0) {
+        return {
+          monthInReview: 'No weekly summaries found for this month.',
+          accomplishments: '',
+          growth: '',
+          lookingAhead: '',
+          errors: [],
+        };
+      }
 
-  // Early exit: no weekly summaries to consolidate
-  if (!weeklySummaries || weeklySummaries.length === 0) {
-    return {
-      monthInReview: 'No weekly summaries found for this month.',
-      accomplishments: '',
-      growth: '',
-      lookingAhead: '',
-      errors: [],
-    };
-  }
+      try {
+        const prompt = monthlySummaryPrompt(weeklySummaries.length);
+        const formattedSummaries = formatWeeklySummariesForMonthly(weeklySummaries);
 
-  try {
-    const prompt = monthlySummaryPrompt(weeklySummaries.length);
-    const formattedSummaries = formatWeeklySummariesForMonthly(weeklySummaries);
+        const result = await getModel(0.7).invoke([
+          new SystemMessage(prompt),
+          new HumanMessage(formattedSummaries),
+        ]);
 
-    const result = await getModel(0.7).invoke([
-      new SystemMessage(prompt),
-      new HumanMessage(formattedSummaries),
-    ]);
+        if (result.id != null) {
+          span.setAttribute('gen_ai.response.id', result.id);
+        }
+        if (result.usage_metadata != null) {
+          span.setAttribute('gen_ai.usage.input_tokens', result.usage_metadata.input_tokens);
+          span.setAttribute('gen_ai.usage.output_tokens', result.usage_metadata.output_tokens);
+        }
 
-    const cleaned = cleanMonthlySummaryOutput(result.content);
-    const sections = parseMonthlySummarySections(cleaned);
+        const cleaned = cleanMonthlySummaryOutput(result.content);
+        const sections = parseMonthlySummarySections(cleaned);
 
-    return {
-      monthInReview: sections.monthInReview,
-      accomplishments: sections.accomplishments,
-      growth: sections.growth,
-      lookingAhead: sections.lookingAhead,
-      errors: [],
-    };
-  } catch (error) {
-    return {
-      monthInReview: '[Monthly summary generation failed]',
-      accomplishments: '',
-      growth: '',
-      lookingAhead: '',
-      errors: [`Monthly summary generation failed: ${error.message}`],
-    };
-  }
+        return {
+          monthInReview: sections.monthInReview,
+          accomplishments: sections.accomplishments,
+          growth: sections.growth,
+          lookingAhead: sections.lookingAhead,
+          errors: [],
+        };
+      } catch (error) {
+        span.recordException(error);
+        span.setStatus({ code: SpanStatusCode.ERROR });
+        return {
+          monthInReview: '[Monthly summary generation failed]',
+          accomplishments: '',
+          growth: '',
+          lookingAhead: '',
+          errors: [`Monthly summary generation failed: ${error.message}`],
+        };
+      }
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -621,15 +715,26 @@ function getMonthlyGraph() {
  * @returns {Promise<{ monthInReview: string, accomplishments: string, growth: string, lookingAhead: string, errors: string[], generatedAt: Date }>}
  */
 export async function generateMonthlySummary(weeklySummaries, monthLabel) {
-  const graph = getMonthlyGraph();
-  const result = await graph.invoke({ weeklySummaries, monthLabel });
+  return tracer.startActiveSpan('commit_story.summary.generate_monthly_summary', async (span) => {
+    try {
+      span.setAttribute('commit_story.summarize.input_count', weeklySummaries != null ? weeklySummaries.length : 0);
+      const graph = getMonthlyGraph();
+      const result = await graph.invoke({ weeklySummaries, monthLabel });
 
-  return {
-    monthInReview: result.monthInReview || '',
-    accomplishments: result.accomplishments || '',
-    growth: result.growth || '',
-    lookingAhead: result.lookingAhead || '',
-    errors: result.errors || [],
-    generatedAt: new Date(),
-  };
+      return {
+        monthInReview: result.monthInReview || '',
+        accomplishments: result.accomplishments || '',
+        growth: result.growth || '',
+        lookingAhead: result.lookingAhead || '',
+        errors: result.errors || [],
+        generatedAt: new Date(),
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }

--- a/src/index.instrumentation.md
+++ b/src/index.instrumentation.md
@@ -1,0 +1,21 @@
+# Instrumentation Report: src/index.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 5.4K
+- **Output tokens**: 14.2K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- main() is the CLI entry point and would normally require a root span (COV-001), but every significant exit path in the function calls process.exit() — including skip conditions, validation failures, and the happy-path success at the end. Adding tracer.startActiveSpan() around the body would cause the span to leak (never reach the finally block's span.end()) in every process.exit() path. CDQ-001 explicitly prohibits span instrumentation that cannot be cleanly closed, so main() is left uninstrumented. See suggestedRefactors for the extraction pattern that would unblock this.
+- handleSummarize() dispatches to weekly, monthly, and daily summarize modes, each branch ending with process.exit(). Like main(), every code path exits via process.exit() rather than returning, making it impossible to close a span in a finally block. The function is left uninstrumented for the same CDQ-001 reason. See suggestedRefactors for the recommended structural change.
+- All other functions in this file are either synchronous (debug, parseArgs, showHelp, isGitRepository, isValidCommitRef, validateEnvironment, getPreviousCommitTime) or unexported. Synchronous helpers with no I/O are skipped per RST-001; unexported functions are skipped per RST-004. None of them individually perform async I/O that would require their own span separate from an orchestrating parent.
+- The traceloop-init.js import suggests that OpenLLMetry auto-instrumentation is already registered at startup, which means calls to external LLM providers (Anthropic) that happen in the child functions called from main() should already be covered by auto-instrumentation without additional manual wrapping in this file.
+
+## Advisory Findings
+- COV-004 (Async Operation Spans):208: "handleSummarize" (async function) at line 208 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.
+- COV-004 (Async Operation Spans):372: "main" (async function) at line 372 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.

--- a/src/integrators/context-integrator.instrumentation.md
+++ b/src/integrators/context-integrator.instrumentation.md
@@ -1,0 +1,21 @@
+# Instrumentation Report: src/integrators/context-integrator.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 1
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 2.2K
+- **Output tokens**: 6.4K
+- **Cached tokens**: 19.7K
+
+## Schema Extensions
+- `span.commit_story.context.gather_context`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- gatherContextForCommit is the primary service entry point — it orchestrates git data collection, chat message collection, filtering, token budgeting, and sensitive-data redaction. The new span name commit_story.context.gather_context was invented because no existing schema span covers this top-level orchestrator role (the existing span.commit_story.context.collect_chat_messages is already used by the claude-collector file and describes a narrower sub-operation).
+- formatContextForPrompt is a synchronous pure data transformation that converts an already-built context object into a string — no I/O, no async, no network/disk access. It was skipped (RST-001: no spans on synchronous utilities without I/O).
+- getContextSummary is a synchronous accessor that extracts a subset of fields from the context object — single-purpose, no I/O. It was skipped (RST-001).
+- All seven attributes set on the gather_context span (vcs.ref.head.revision, commit_story.context.time_window_start/end, commit_story.context.messages_count/sessions_count, commit_story.filter.messages_before/after) are registered in the Weaver schema — attributesCreated is 0. CDQ-007 PII fields (author, authorEmail) were deliberately excluded from span attributes.

--- a/src/integrators/context-integrator.js
+++ b/src/integrators/context-integrator.js
@@ -6,11 +6,14 @@
  * token budget limits, and sensitive data redaction.
  */
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { getCommitData, getPreviousCommitTime } from '../collectors/git-collector.js';
 import { collectChatMessages } from '../collectors/claude-collector.js';
 import { filterMessages, groupFilteredBySession } from './filters/message-filter.js';
 import { applyTokenBudget, estimateTokens } from './filters/token-filter.js';
 import { applySensitiveFilter } from './filters/sensitive-filter.js';
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Gather all context for a commit
@@ -24,86 +27,105 @@ import { applySensitiveFilter } from './filters/sensitive-filter.js';
  * @returns {Promise<Context>} Gathered and filtered context
  */
 export async function gatherContextForCommit(commitRef = 'HEAD', options = {}) {
-  const {
-    repoPath = process.cwd(),
-    tokenBudget = 150000,
-    diffBudget = 50000,
-    chatBudget = 80000,
-    redactEmails = false,
-  } = options;
+  return tracer.startActiveSpan('commit_story.context.gather_context', async (span) => {
+    try {
+      const {
+        repoPath = process.cwd(),
+        tokenBudget = 150000,
+        diffBudget = 50000,
+        chatBudget = 80000,
+        redactEmails = false,
+      } = options;
 
-  // 1. Collect git data
-  const commitData = await getCommitData(commitRef);
+      span.setAttribute('vcs.ref.head.revision', commitRef);
 
-  // 2. Get previous commit time for chat window
-  const previousCommitTime = await getPreviousCommitTime(commitRef);
+      // 1. Collect git data
+      const commitData = await getCommitData(commitRef);
 
-  // 3. Collect chat messages
-  let chatData;
-  if (previousCommitTime) {
-    chatData = await collectChatMessages(repoPath, commitData.timestamp, previousCommitTime);
-  } else {
-    // First commit - use 24 hours before as window
-    const dayBefore = new Date(commitData.timestamp.getTime() - 24 * 60 * 60 * 1000);
-    chatData = await collectChatMessages(repoPath, commitData.timestamp, dayBefore);
-  }
+      // 2. Get previous commit time for chat window
+      const previousCommitTime = await getPreviousCommitTime(commitRef);
 
-  // 4. Filter chat messages
-  const { messages: filteredMessages, stats: filterStats } = filterMessages(chatData.messages);
+      // 3. Collect chat messages
+      let chatData;
+      if (previousCommitTime) {
+        chatData = await collectChatMessages(repoPath, commitData.timestamp, previousCommitTime);
+      } else {
+        // First commit - use 24 hours before as window
+        const dayBefore = new Date(commitData.timestamp.getTime() - 24 * 60 * 60 * 1000);
+        chatData = await collectChatMessages(repoPath, commitData.timestamp, dayBefore);
+      }
 
-  // 5. Group filtered messages by session
-  const filteredSessions = groupFilteredBySession(filteredMessages);
+      // 4. Filter chat messages
+      const { messages: filteredMessages, stats: filterStats } = filterMessages(chatData.messages);
 
-  // 6. Build initial context object
-  let context = {
-    commit: {
-      hash: commitData.hash,
-      shortHash: commitData.shortHash,
-      message: commitData.message,
-      subject: commitData.subject,
-      author: commitData.author,
-      authorEmail: commitData.authorEmail,
-      timestamp: commitData.timestamp,
-      diff: commitData.diff,
-      isMerge: commitData.isMerge,
-      parentCount: commitData.parentCount,
-    },
-    chat: {
-      messages: filteredMessages,
-      sessions: filteredSessions,
-      messageCount: filteredMessages.length,
-      sessionCount: filteredSessions.size,
-    },
-    metadata: {
-      previousCommitTime,
-      timeWindow: {
-        start: previousCommitTime || new Date(commitData.timestamp.getTime() - 24 * 60 * 60 * 1000),
-        end: commitData.timestamp,
-      },
-      filterStats: {
-        totalMessages: filterStats.total,
-        filteredMessages: filterStats.filtered,
-        preservedMessages: filterStats.preserved,
-        substantialUserMessages: filterStats.substantialUserMessages,
-        filterReasons: filterStats.byReason,
-      },
-      tokenEstimate: 0, // Will be calculated after budget applied
-    },
-  };
+      // 5. Group filtered messages by session
+      const filteredSessions = groupFilteredBySession(filteredMessages);
 
-  // 7. Apply token budget limits
-  context = applyTokenBudget(context, {
-    totalBudget: tokenBudget,
-    diffBudget,
-    chatBudget,
+      // 6. Build initial context object
+      let context = {
+        commit: {
+          hash: commitData.hash,
+          shortHash: commitData.shortHash,
+          message: commitData.message,
+          subject: commitData.subject,
+          author: commitData.author,
+          authorEmail: commitData.authorEmail,
+          timestamp: commitData.timestamp,
+          diff: commitData.diff,
+          isMerge: commitData.isMerge,
+          parentCount: commitData.parentCount,
+        },
+        chat: {
+          messages: filteredMessages,
+          sessions: filteredSessions,
+          messageCount: filteredMessages.length,
+          sessionCount: filteredSessions.size,
+        },
+        metadata: {
+          previousCommitTime,
+          timeWindow: {
+            start: previousCommitTime || new Date(commitData.timestamp.getTime() - 24 * 60 * 60 * 1000),
+            end: commitData.timestamp,
+          },
+          filterStats: {
+            totalMessages: filterStats.total,
+            filteredMessages: filterStats.filtered,
+            preservedMessages: filterStats.preserved,
+            substantialUserMessages: filterStats.substantialUserMessages,
+            filterReasons: filterStats.byReason,
+          },
+          tokenEstimate: 0, // Will be calculated after budget applied
+        },
+      };
+
+      span.setAttribute('commit_story.context.time_window_start', context.metadata.timeWindow.start.toISOString());
+      span.setAttribute('commit_story.context.time_window_end', context.metadata.timeWindow.end.toISOString());
+      span.setAttribute('commit_story.context.messages_count', filteredMessages.length);
+      span.setAttribute('commit_story.context.sessions_count', filteredSessions.size);
+      span.setAttribute('commit_story.filter.messages_before', filterStats.total);
+      span.setAttribute('commit_story.filter.messages_after', filterStats.preserved);
+
+      // 7. Apply token budget limits
+      context = applyTokenBudget(context, {
+        totalBudget: tokenBudget,
+        diffBudget,
+        chatBudget,
+      });
+
+      // 8. Apply sensitive data redaction
+      context = applySensitiveFilter(context, {
+        redactEmails,
+      });
+
+      return context;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
   });
-
-  // 8. Apply sensitive data redaction
-  context = applySensitiveFilter(context, {
-    redactEmails,
-  });
-
-  return context;
 }
 
 /**

--- a/src/integrators/filters/message-filter.instrumentation.md
+++ b/src/integrators/filters/message-filter.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/integrators/filters/message-filter.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- All exported functions are synchronous (filterMessages, groupFilteredBySession) — no async I/O to trace. No LLM call made.

--- a/src/integrators/filters/sensitive-filter.instrumentation.md
+++ b/src/integrators/filters/sensitive-filter.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/integrators/filters/sensitive-filter.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- All exported functions are synchronous (redactSensitiveData, redactDiff, redactMessages, applySensitiveFilter) — no async I/O to trace. No LLM call made.

--- a/src/integrators/filters/token-filter.instrumentation.md
+++ b/src/integrators/filters/token-filter.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/integrators/filters/token-filter.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- All exported functions are synchronous (estimateTokens, truncateDiff, truncateMessages, applyTokenBudget) — no async I/O to trace. No LLM call made.

--- a/src/managers/auto-summarize.instrumentation.md
+++ b/src/managers/auto-summarize.instrumentation.md
@@ -1,0 +1,23 @@
+# Instrumentation Report: src/managers/auto-summarize.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 3
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 2.2K
+- **Output tokens**: 6.1K
+
+## Schema Extensions
+- `span.commit_story.summarize.trigger_auto_summaries`
+- `span.commit_story.summarize.trigger_auto_weekly`
+- `span.commit_story.summarize.trigger_auto_monthly`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- getErrorMessage is a pure synchronous helper that returns a string — no I/O, no async, under 5 lines. Skipped per RST-001 (no spans on synchronous utilities).
+- The schema defines span IDs commit_story.summarize.run_daily, run_weekly, and run_monthly, but all three were reported as already in use by earlier files in this run. New unique span names commit_story.summarize.trigger_auto_summaries, trigger_auto_weekly, and trigger_auto_monthly were invented and registered as schema extensions (SCH-001 cannot apply when the matching names are already claimed).
+- The per-iteration catch blocks inside the for loops collect failures into result.failed and result.errors without rethrowing — these represent expected control flow (individual items failing while the loop continues). recordException and setStatus were NOT added to those catches, only to the outer span-lifecycle catch wrapping each function body (CDQ-003 exemption for expected-condition catches).
+- In triggerAutoSummaries the early-return path (when result.failed.length > 0) sets generated_count and failed_count before returning, and the normal path extracts the final merged object to a const so attributes can be set before the return. This is the only allowed non-instrumentation variable extraction.
+- All three attribute keys used (commit_story.summarize.input_count, commit_story.summarize.generated_count, commit_story.summarize.failed_count) are registered in the Weaver schema — no new attribute schema extensions were needed (attributesCreated = 0).

--- a/src/managers/auto-summarize.js
+++ b/src/managers/auto-summarize.js
@@ -1,8 +1,11 @@
 // ABOUTME: Auto-trigger logic for daily, weekly, and monthly summaries after journal entry creation
 // ABOUTME: Detects unsummarized past days/weeks/months and generates summaries with progress reporting
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { findUnsummarizedDays, findUnsummarizedWeeks, findUnsummarizedMonths } from '../utils/summary-detector.js';
 import { generateAndSaveDailySummary, generateAndSaveWeeklySummary, generateAndSaveMonthlySummary } from './summary-manager.js';
+
+const tracer = trace.getTracer('commit-story');
 
 function getErrorMessage(err) {
   return err instanceof Error ? err.message : String(err);
@@ -18,72 +21,88 @@ function getErrorMessage(err) {
  * @returns {Promise<{ generated: string[], skipped: string[], failed: string[], errors: string[] }>}
  */
 export async function triggerAutoSummaries(basePath = '.', options = {}) {
-  const { onProgress } = options;
-
-  const unsummarizedDays = await findUnsummarizedDays(basePath);
-
-  const result = {
-    generated: [],
-    skipped: [],
-    failed: [],
-    errors: [],
-  };
-
-  for (const dateStr of unsummarizedDays) {
-    const date = new Date(
-      parseInt(dateStr.slice(0, 4)),
-      parseInt(dateStr.slice(5, 7)) - 1,
-      parseInt(dateStr.slice(8, 10)),
-    );
-
+  return tracer.startActiveSpan('commit_story.summarize.trigger_auto_summaries', async (span) => {
     try {
-      const summaryResult = await generateAndSaveDailySummary(date, basePath);
+      const { onProgress } = options;
 
-      if (summaryResult.saved) {
-        result.generated.push(summaryResult.path);
-        if (onProgress) {
-          onProgress(`Generated daily summary for ${dateStr}`);
-        }
+      const unsummarizedDays = await findUnsummarizedDays(basePath);
+      span.setAttribute('commit_story.summarize.input_count', unsummarizedDays.length);
 
-        // Track errors from generation (partial issues like LLM timeouts)
-        if (summaryResult.errors && summaryResult.errors.length > 0) {
-          for (const err of summaryResult.errors) {
-            result.errors.push(`${dateStr}: ${err}`);
+      const result = {
+        generated: [],
+        skipped: [],
+        failed: [],
+        errors: [],
+      };
+
+      for (const dateStr of unsummarizedDays) {
+        const date = new Date(
+          parseInt(dateStr.slice(0, 4)),
+          parseInt(dateStr.slice(5, 7)) - 1,
+          parseInt(dateStr.slice(8, 10)),
+        );
+
+        try {
+          const summaryResult = await generateAndSaveDailySummary(date, basePath);
+
+          if (summaryResult.saved) {
+            result.generated.push(summaryResult.path);
+            if (onProgress) {
+              onProgress(`Generated daily summary for ${dateStr}`);
+            }
+
+            // Track errors from generation (partial issues like LLM timeouts)
+            if (summaryResult.errors && summaryResult.errors.length > 0) {
+              for (const err of summaryResult.errors) {
+                result.errors.push(`${dateStr}: ${err}`);
+              }
+            }
+          } else {
+            result.skipped.push(dateStr);
+          }
+        } catch (err) {
+          result.failed.push(dateStr);
+          result.errors.push(`${dateStr}: ${getErrorMessage(err)}`);
+          if (onProgress) {
+            onProgress(`Failed to generate summary for ${dateStr}: ${getErrorMessage(err)}`);
           }
         }
-      } else {
-        result.skipped.push(dateStr);
       }
-    } catch (err) {
-      result.failed.push(dateStr);
-      result.errors.push(`${dateStr}: ${getErrorMessage(err)}`);
-      if (onProgress) {
-        onProgress(`Failed to generate summary for ${dateStr}: ${getErrorMessage(err)}`);
+
+      // Skip higher-cadence rollups if daily generation had failures —
+      // prevents locking in incomplete weekly/monthly via duplicate detection
+      if (result.failed.length > 0) {
+        if (onProgress) {
+          onProgress('Skipped weekly/monthly auto-summaries because daily generation had failures');
+        }
+        span.setAttribute('commit_story.summarize.generated_count', result.generated.length);
+        span.setAttribute('commit_story.summarize.failed_count', result.failed.length);
+        return result;
       }
+
+      // After daily summaries are generated, check for unsummarized weeks
+      const weeklyResult = await triggerAutoWeeklySummaries(basePath, options);
+
+      // After weekly summaries are generated, check for unsummarized months
+      const monthlyResult = await triggerAutoMonthlySummaries(basePath, options);
+
+      const finalResult = {
+        generated: [...result.generated, ...weeklyResult.generated, ...monthlyResult.generated],
+        skipped: [...result.skipped, ...weeklyResult.skipped, ...monthlyResult.skipped],
+        failed: [...result.failed, ...weeklyResult.failed, ...monthlyResult.failed],
+        errors: [...result.errors, ...weeklyResult.errors, ...monthlyResult.errors],
+      };
+      span.setAttribute('commit_story.summarize.generated_count', finalResult.generated.length);
+      span.setAttribute('commit_story.summarize.failed_count', finalResult.failed.length);
+      return finalResult;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  // Skip higher-cadence rollups if daily generation had failures —
-  // prevents locking in incomplete weekly/monthly via duplicate detection
-  if (result.failed.length > 0) {
-    if (onProgress) {
-      onProgress('Skipped weekly/monthly auto-summaries because daily generation had failures');
-    }
-    return result;
-  }
-
-  // After daily summaries are generated, check for unsummarized weeks
-  const weeklyResult = await triggerAutoWeeklySummaries(basePath, options);
-
-  // After weekly summaries are generated, check for unsummarized months
-  const monthlyResult = await triggerAutoMonthlySummaries(basePath, options);
-
-  return {
-    generated: [...result.generated, ...weeklyResult.generated, ...monthlyResult.generated],
-    skipped: [...result.skipped, ...weeklyResult.skipped, ...monthlyResult.skipped],
-    failed: [...result.failed, ...weeklyResult.failed, ...monthlyResult.failed],
-    errors: [...result.errors, ...weeklyResult.errors, ...monthlyResult.errors],
-  };
+  });
 }
 
 /**
@@ -95,45 +114,58 @@ export async function triggerAutoSummaries(basePath = '.', options = {}) {
  * @returns {Promise<{ generated: string[], skipped: string[], failed: string[], errors: string[] }>}
  */
 export async function triggerAutoWeeklySummaries(basePath = '.', options = {}) {
-  const { onProgress } = options;
-
-  const unsummarizedWeeks = await findUnsummarizedWeeks(basePath);
-
-  const result = {
-    generated: [],
-    skipped: [],
-    failed: [],
-    errors: [],
-  };
-
-  for (const weekStr of unsummarizedWeeks) {
+  return tracer.startActiveSpan('commit_story.summarize.trigger_auto_weekly', async (span) => {
     try {
-      const summaryResult = await generateAndSaveWeeklySummary(weekStr, basePath);
+      const { onProgress } = options;
 
-      if (summaryResult.saved) {
-        result.generated.push(summaryResult.path);
-        if (onProgress) {
-          onProgress(`Generated weekly summary for ${weekStr}`);
-        }
+      const unsummarizedWeeks = await findUnsummarizedWeeks(basePath);
+      span.setAttribute('commit_story.summarize.input_count', unsummarizedWeeks.length);
 
-        if (summaryResult.errors && summaryResult.errors.length > 0) {
-          for (const err of summaryResult.errors) {
-            result.errors.push(`${weekStr}: ${err}`);
+      const result = {
+        generated: [],
+        skipped: [],
+        failed: [],
+        errors: [],
+      };
+
+      for (const weekStr of unsummarizedWeeks) {
+        try {
+          const summaryResult = await generateAndSaveWeeklySummary(weekStr, basePath);
+
+          if (summaryResult.saved) {
+            result.generated.push(summaryResult.path);
+            if (onProgress) {
+              onProgress(`Generated weekly summary for ${weekStr}`);
+            }
+
+            if (summaryResult.errors && summaryResult.errors.length > 0) {
+              for (const err of summaryResult.errors) {
+                result.errors.push(`${weekStr}: ${err}`);
+              }
+            }
+          } else {
+            result.skipped.push(weekStr);
+          }
+        } catch (err) {
+          result.failed.push(weekStr);
+          result.errors.push(`${weekStr}: ${getErrorMessage(err)}`);
+          if (onProgress) {
+            onProgress(`Failed to generate weekly summary for ${weekStr}: ${getErrorMessage(err)}`);
           }
         }
-      } else {
-        result.skipped.push(weekStr);
       }
-    } catch (err) {
-      result.failed.push(weekStr);
-      result.errors.push(`${weekStr}: ${getErrorMessage(err)}`);
-      if (onProgress) {
-        onProgress(`Failed to generate weekly summary for ${weekStr}: ${getErrorMessage(err)}`);
-      }
-    }
-  }
 
-  return result;
+      span.setAttribute('commit_story.summarize.generated_count', result.generated.length);
+      span.setAttribute('commit_story.summarize.failed_count', result.failed.length);
+      return result;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -145,43 +177,56 @@ export async function triggerAutoWeeklySummaries(basePath = '.', options = {}) {
  * @returns {Promise<{ generated: string[], skipped: string[], failed: string[], errors: string[] }>}
  */
 export async function triggerAutoMonthlySummaries(basePath = '.', options = {}) {
-  const { onProgress } = options;
-
-  const unsummarizedMonths = await findUnsummarizedMonths(basePath);
-
-  const result = {
-    generated: [],
-    skipped: [],
-    failed: [],
-    errors: [],
-  };
-
-  for (const monthStr of unsummarizedMonths) {
+  return tracer.startActiveSpan('commit_story.summarize.trigger_auto_monthly', async (span) => {
     try {
-      const summaryResult = await generateAndSaveMonthlySummary(monthStr, basePath);
+      const { onProgress } = options;
 
-      if (summaryResult.saved) {
-        result.generated.push(summaryResult.path);
-        if (onProgress) {
-          onProgress(`Generated monthly summary for ${monthStr}`);
-        }
+      const unsummarizedMonths = await findUnsummarizedMonths(basePath);
+      span.setAttribute('commit_story.summarize.input_count', unsummarizedMonths.length);
 
-        if (summaryResult.errors && summaryResult.errors.length > 0) {
-          for (const err of summaryResult.errors) {
-            result.errors.push(`${monthStr}: ${err}`);
+      const result = {
+        generated: [],
+        skipped: [],
+        failed: [],
+        errors: [],
+      };
+
+      for (const monthStr of unsummarizedMonths) {
+        try {
+          const summaryResult = await generateAndSaveMonthlySummary(monthStr, basePath);
+
+          if (summaryResult.saved) {
+            result.generated.push(summaryResult.path);
+            if (onProgress) {
+              onProgress(`Generated monthly summary for ${monthStr}`);
+            }
+
+            if (summaryResult.errors && summaryResult.errors.length > 0) {
+              for (const err of summaryResult.errors) {
+                result.errors.push(`${monthStr}: ${err}`);
+              }
+            }
+          } else {
+            result.skipped.push(monthStr);
+          }
+        } catch (err) {
+          result.failed.push(monthStr);
+          result.errors.push(`${monthStr}: ${getErrorMessage(err)}`);
+          if (onProgress) {
+            onProgress(`Failed to generate monthly summary for ${monthStr}: ${getErrorMessage(err)}`);
           }
         }
-      } else {
-        result.skipped.push(monthStr);
       }
-    } catch (err) {
-      result.failed.push(monthStr);
-      result.errors.push(`${monthStr}: ${getErrorMessage(err)}`);
-      if (onProgress) {
-        onProgress(`Failed to generate monthly summary for ${monthStr}: ${getErrorMessage(err)}`);
-      }
-    }
-  }
 
-  return result;
+      span.setAttribute('commit_story.summarize.generated_count', result.generated.length);
+      span.setAttribute('commit_story.summarize.failed_count', result.failed.length);
+      return result;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }

--- a/src/managers/journal-manager.instrumentation.md
+++ b/src/managers/journal-manager.instrumentation.md
@@ -1,0 +1,25 @@
+# Instrumentation Report: src/managers/journal-manager.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 2
+- **Attempts**: 2 (multi-turn-fix)
+- **Input tokens**: 19.4K
+- **Output tokens**: 14.5K
+
+## Schema Extensions
+- `span.commit_story.journal.save_entry`
+- `span.commit_story.journal.discover_reflections`
+
+## Validation Journey
+1. **Attempt 1**: 2 blocking errors (NDS-003 (Code Preserved):2)
+2. **Attempt 2**: 0 errors
+
+## Notes
+- The import of 'node:path' is preserved exactly as the original `import { join } from 'node:path'`. To avoid modifying that line (NDS-003), basename is not imported. Instead, `entryPath.split('/').pop()` extracts the filename for the commit_story.journal.file_path attribute, achieving the same CDQ-007 compliance without touching the original import.
+- formatTimestamp, formatJournalEntry, formatReflectionsSection, extractFilesFromDiff, countDiffLines, parseReflectionEntry, parseTimeString, parseReflectionsFile, isInTimeWindow, and getYearMonthRange are all pure synchronous functions with no async I/O — excluded from instrumentation (RST-001, RST-004).
+- The inner try/catch blocks in saveJournalEntry (ENOENT check) and discoverReflections (missing directory, unreadable file) are expected-condition catches with empty bodies — no recordException or setStatus is added to those, per the error handling constraint for control-flow catches.
+- discoverReflections uses commit_story.journal.quotes_count for the final reflection count because discovered reflections represent developer quotes captured during a commit window — the schema's quotes_count field semantically matches this output count.
+
+## Advisory Findings
+- CDQ-006 (isRecording Guard):187: setAttribute value "entryPath.split('/').pop()" at line 187 has an expensive computation without span.isRecording() guard. Wrap expensive attribute computations in an if (span.isRecording()) check to avoid unnecessary computation when the span is not being sampled.

--- a/src/managers/journal-manager.js
+++ b/src/managers/journal-manager.js
@@ -5,6 +5,7 @@
  * Uses fs/promises for async file operations and UTC-first time handling.
  */
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { readFile, appendFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
@@ -14,6 +15,8 @@ import {
   parseDateFromFilename,
   getYearMonth,
 } from '../utils/journal-paths.js';
+
+const tracer = trace.getTracer('commit-story');
 
 /** Separator between journal entries */
 const ENTRY_SEPARATOR = '\n═══════════════════════════════════════\n\n';
@@ -175,48 +178,67 @@ export function formatJournalEntry(sections, commit, reflections = []) {
  * @returns {Promise<string>} Path to saved file
  */
 export async function saveJournalEntry(sections, commit, reflections = [], basePath = '.', options = {}) {
-  const log = options.debug || (() => {});
-  const entryPath = getJournalEntryPath(commit.timestamp, basePath);
+  return tracer.startActiveSpan('commit_story.journal.save_entry', async (span) => {
+    try {
+      const log = options.debug || (() => {});
+      const entryPath = getJournalEntryPath(commit.timestamp, basePath);
 
-  // Ensure directory exists
-  await ensureDirectory(entryPath);
+      span.setAttribute('commit_story.commit.timestamp', new Date(commit.timestamp).toISOString());
+      span.setAttribute('commit_story.journal.file_path', entryPath.split('/').pop());
+      if (commit.hash != null) {
+        span.setAttribute('vcs.ref.head.revision', commit.hash);
+      }
+      if (commit.filesChanged != null) {
+        span.setAttribute('commit_story.commit.files_changed', commit.filesChanged);
+      }
 
-  // Check for duplicate entry
-  try {
-    const existing = await readFile(entryPath, 'utf-8');
+      // Ensure directory exists
+      await ensureDirectory(entryPath);
 
-    // Path 1: Exact hash match (catches re-runs of the same commit)
-    if (existing.includes(`Commit: ${commit.shortHash}`)) {
-      log(`Skipping duplicate entry: exact hash match (${commit.shortHash})`);
+      // Check for duplicate entry
+      try {
+        const existing = await readFile(entryPath, 'utf-8');
+
+        // Path 1: Exact hash match (catches re-runs of the same commit)
+        if (existing.includes(`Commit: ${commit.shortHash}`)) {
+          log(`Skipping duplicate entry: exact hash match (${commit.shortHash})`);
+          return entryPath;
+        }
+
+        // Path 2: Semantic match (catches cherry-pick/rebase duplicates)
+        // Cherry-picks and rebases preserve author timestamp and commit message
+        // but produce a new commit hash. Match on both to avoid false positives.
+        // Split into entry blocks so we check timestamp+message within the SAME entry,
+        // avoiding false positives when different entries share one field each.
+        const timeStr = formatTimestamp(commit.timestamp);
+        const commitMessage = (commit.message || '').split('\n')[0];
+        const entryBlocks = existing.split('═══════════════════════════════════════');
+        const isSemanticDup = commitMessage && entryBlocks.some(
+          block => block.includes(`## ${timeStr}`) && block.includes(`**Message**: "${commitMessage}"`)
+        );
+        if (isSemanticDup) {
+          log(`Skipping duplicate entry: semantic match — same timestamp (${timeStr}) and message ("${commitMessage}"), likely cherry-pick/rebase of ${commit.shortHash}`);
+          return entryPath;
+        }
+      } catch {
+        // File doesn't exist yet, proceed
+      }
+
+      // Format the entry
+      const formattedEntry = formatJournalEntry(sections, commit, reflections);
+
+      // Append to file (creates if doesn't exist)
+      await appendFile(entryPath, formattedEntry + '\n', 'utf-8');
+
       return entryPath;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-
-    // Path 2: Semantic match (catches cherry-pick/rebase duplicates)
-    // Cherry-picks and rebases preserve author timestamp and commit message
-    // but produce a new commit hash. Match on both to avoid false positives.
-    // Split into entry blocks so we check timestamp+message within the SAME entry,
-    // avoiding false positives when different entries share one field each.
-    const timeStr = formatTimestamp(commit.timestamp);
-    const commitMessage = (commit.message || '').split('\n')[0];
-    const entryBlocks = existing.split('═══════════════════════════════════════');
-    const isSemanticDup = commitMessage && entryBlocks.some(
-      block => block.includes(`## ${timeStr}`) && block.includes(`**Message**: "${commitMessage}"`)
-    );
-    if (isSemanticDup) {
-      log(`Skipping duplicate entry: semantic match — same timestamp (${timeStr}) and message ("${commitMessage}"), likely cherry-pick/rebase of ${commit.shortHash}`);
-      return entryPath;
-    }
-  } catch {
-    // File doesn't exist yet, proceed
-  }
-
-  // Format the entry
-  const formattedEntry = formatJournalEntry(sections, commit, reflections);
-
-  // Append to file (creates if doesn't exist)
-  await appendFile(entryPath, formattedEntry + '\n', 'utf-8');
-
-  return entryPath;
+  });
 }
 
 /**
@@ -325,71 +347,85 @@ function isInTimeWindow(timestamp, startTime, endTime) {
  * @returns {Promise<Array>} Array of reflections sorted chronologically
  */
 export async function discoverReflections(startTime, endTime, basePath = '.') {
-  const reflections = [];
-
-  // Get all year-month directories that could contain relevant reflections
-  const startYearMonth = getYearMonth(startTime);
-  const endYearMonth = getYearMonth(endTime);
-  const yearMonths = getYearMonthRange(startYearMonth, endYearMonth);
-
-  for (const yearMonth of yearMonths) {
-    const reflectionsDir = join(basePath, 'journal', 'reflections', yearMonth);
-
+  return tracer.startActiveSpan('commit_story.journal.discover_reflections', async (span) => {
     try {
-      const files = await readdir(reflectionsDir);
+      span.setAttribute('commit_story.context.time_window_start', startTime.toISOString());
+      span.setAttribute('commit_story.context.time_window_end', endTime.toISOString());
 
-      for (const file of files) {
-        if (!file.endsWith('.md')) {
-          continue;
-        }
+      const reflections = [];
 
-        const fileDate = parseDateFromFilename(file);
-        if (!fileDate) {
-          continue;
-        }
+      // Get all year-month directories that could contain relevant reflections
+      const startYearMonth = getYearMonth(startTime);
+      const endYearMonth = getYearMonth(endTime);
+      const yearMonths = getYearMonthRange(startYearMonth, endYearMonth);
 
-        // Quick check: skip files outside the date range
-        // (dates are at start of day, so include if within range)
-        const fileDateEnd = new Date(fileDate);
-        fileDateEnd.setHours(23, 59, 59, 999);
+      for (const yearMonth of yearMonths) {
+        const reflectionsDir = join(basePath, 'journal', 'reflections', yearMonth);
 
-        if (fileDateEnd.getTime() < startTime.getTime()) {
-          continue;
-        }
-        if (fileDate.getTime() > endTime.getTime()) {
-          continue;
-        }
-
-        // Read and parse reflections from file
-        const filePath = join(reflectionsDir, file);
         try {
-          const content = await readFile(filePath, 'utf-8');
-          const fileReflections = parseReflectionsFile(content, fileDate);
+          const files = await readdir(reflectionsDir);
 
-          // Filter to time window
-          for (const reflection of fileReflections) {
-            if (isInTimeWindow(reflection.timestamp, startTime, endTime)) {
-              reflections.push({
-                ...reflection,
-                filePath,
-              });
+          for (const file of files) {
+            if (!file.endsWith('.md')) {
+              continue;
+            }
+
+            const fileDate = parseDateFromFilename(file);
+            if (!fileDate) {
+              continue;
+            }
+
+            // Quick check: skip files outside the date range
+            // (dates are at start of day, so include if within range)
+            const fileDateEnd = new Date(fileDate);
+            fileDateEnd.setHours(23, 59, 59, 999);
+
+            if (fileDateEnd.getTime() < startTime.getTime()) {
+              continue;
+            }
+            if (fileDate.getTime() > endTime.getTime()) {
+              continue;
+            }
+
+            // Read and parse reflections from file
+            const filePath = join(reflectionsDir, file);
+            try {
+              const content = await readFile(filePath, 'utf-8');
+              const fileReflections = parseReflectionsFile(content, fileDate);
+
+              // Filter to time window
+              for (const reflection of fileReflections) {
+                if (isInTimeWindow(reflection.timestamp, startTime, endTime)) {
+                  reflections.push({
+                    ...reflection,
+                    filePath,
+                  });
+                }
+              }
+            } catch {
+              // Skip files that can't be read
+              continue;
             }
           }
         } catch {
-          // Skip files that can't be read
+          // Directory doesn't exist, skip
           continue;
         }
       }
-    } catch {
-      // Directory doesn't exist, skip
-      continue;
+
+      // Sort chronologically
+      reflections.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+      span.setAttribute('commit_story.journal.quotes_count', reflections.length);
+      return reflections;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  // Sort chronologically
-  reflections.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
-
-  return reflections;
+  });
 }
 
 

--- a/src/managers/summary-manager.instrumentation.md
+++ b/src/managers/summary-manager.instrumentation.md
@@ -1,0 +1,35 @@
+# Instrumentation Report: src/managers/summary-manager.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 3
+- **Attempts**: 3 (fresh-regeneration)
+- **Input tokens**: 49.3K
+- **Output tokens**: 50.3K
+
+## Schema Extensions
+- `span.commit_story.summary.generate_and_save_daily`
+- `span.commit_story.summary.generate_and_save_weekly`
+- `span.commit_story.summary.generate_and_save_monthly`
+- `commit_story.summary.week_label`
+- `commit_story.summary.month_label`
+
+## Validation Journey
+1. **Attempt 1**: 2 blocking errors (NDS-003 (Code Preserved):2)
+2. **Attempt 2**: 7 blocking errors (NDS-003 (Code Preserved):7)
+3. **Attempt 3**: 0 errors
+
+## Notes
+- The three pipeline functions (generateAndSaveDailySummary, generateAndSaveWeeklySummary, generateAndSaveMonthlySummary) are the highest-value instrumentation targets — each orchestrates the full read-generate-save pipeline for a period. The schema span names for these operations (commit_story.summary.generate_daily_summary etc.) were already claimed by earlier files in this run, so new names were invented: generate_and_save_daily/weekly/monthly, reported as schema extensions.
+- formatDailySummary, formatWeeklySummary, formatMonthlySummary, getWeekBoundaries, and getMonthBoundaries are pure synchronous helpers with no I/O — skipped per RST-001 (no spans on synchronous utilities).
+- readDayEntries, saveDailySummary, readWeekDailySummaries, saveWeeklySummary, readMonthWeeklySummaries, and saveMonthlySummary are exported async I/O functions. They were skipped to stay within the ~20% ratio backstop (instrumenting all would cover 64% of functions). Their I/O becomes child spans of the parent pipeline spans through context propagation.
+- Two new schema attributes were introduced: commit_story.summary.week_label (ISO week string like '2026-W09') and commit_story.summary.month_label (month string like '2026-02'). No existing registered key captures these period identifiers — commit_story.journal.entry_date is defined as YYYY-MM-DD format only, making it semantically wrong for week and month strings.
+- The inner access() catch blocks inside each pipeline function are expected-condition catches (checking for pre-existing files as a duplicate-detection guard). They were left without recordException/setStatus because file-not-found is the normal happy path, not an error condition.
+
+## Advisory Findings
+- COV-004 (Async Operation Spans):29: "readDayEntries" (async function) at line 29 is exported and async but has no span. Context propagation is not a valid COV-004 exemption for exported async I/O functions. The only valid reason to skip this function is RST-001 (synchronous, no I/O). RST-004 (unexported function) does not apply since this function is exported.
+- COV-004 (Async Operation Spans):88: "saveDailySummary" (async function) at line 88 is exported and async but has no span. Context propagation is not a valid COV-004 exemption for exported async I/O functions. The only valid reason to skip this function is RST-001 (synchronous, no I/O). RST-004 (unexported function) does not apply since this function is exported.
+- COV-004 (Async Operation Spans):213: "readWeekDailySummaries" (async function) at line 213 is exported and async but has no span. Context propagation is not a valid COV-004 exemption for exported async I/O functions. The only valid reason to skip this function is RST-001 (synchronous, no I/O). RST-004 (unexported function) does not apply since this function is exported.
+- COV-004 (Async Operation Spans):275: "saveWeeklySummary" (async function) at line 275 is exported and async but has no span. Context propagation is not a valid COV-004 exemption for exported async I/O functions. The only valid reason to skip this function is RST-001 (synchronous, no I/O). RST-004 (unexported function) does not apply since this function is exported.
+- COV-004 (Async Operation Spans):394: "readMonthWeeklySummaries" (async function) at line 394 is exported and async but has no span. Context propagation is not a valid COV-004 exemption for exported async I/O functions. The only valid reason to skip this function is RST-001 (synchronous, no I/O). RST-004 (unexported function) does not apply since this function is exported.
+- COV-004 (Async Operation Spans):474: "saveMonthlySummary" (async function) at line 474 is exported and async but has no span. Context propagation is not a valid COV-004 exemption for exported async I/O functions. The only valid reason to skip this function is RST-001 (synchronous, no I/O). RST-004 (unexported function) does not apply since this function is exported.

--- a/src/managers/summary-manager.js
+++ b/src/managers/summary-manager.js
@@ -1,6 +1,7 @@
 // ABOUTME: Orchestrates daily, weekly, and monthly summary generation — reads source content, calls graph, writes output
 // ABOUTME: Handles duplicate detection via file existence (DD-003) and force-regeneration
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { readFile, writeFile, access, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { generateDailySummary, generateWeeklySummary, generateMonthlySummary } from '../generators/summary-graph.js';
@@ -15,6 +16,8 @@ import {
 
 /** Separator between journal entries (matches journal-manager.js) */
 const ENTRY_SEPARATOR = '═══════════════════════════════════════';
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Read all journal entries for a given date.
@@ -110,44 +113,57 @@ export async function saveDailySummary(content, date, basePath = '.', options = 
  * @returns {Promise<{ saved: boolean, path?: string, reason?: string, entryCount?: number, errors?: string[] }>}
  */
 export async function generateAndSaveDailySummary(date, basePath = '.', options = {}) {
-  const dateStr = getDateString(date);
-
-  // Check for existing summary first (avoid reading entries unnecessarily)
-  if (!options.force) {
-    const summaryPath = getSummaryPath('daily', date, basePath);
+  return tracer.startActiveSpan('commit_story.summary.generate_and_save_daily', async (span) => {
     try {
-      await access(summaryPath);
-      return { saved: false, reason: `Summary already exists for ${dateStr}` };
-    } catch {
-      // Doesn't exist, proceed
+      const dateStr = getDateString(date);
+      span.setAttribute('commit_story.journal.entry_date', dateStr);
+      span.setAttribute('commit_story.summarize.force', options.force || false);
+
+      // Check for existing summary first (avoid reading entries unnecessarily)
+      if (!options.force) {
+        const summaryPath = getSummaryPath('daily', date, basePath);
+        try {
+          await access(summaryPath);
+          return { saved: false, reason: `Summary already exists for ${dateStr}` };
+        } catch {
+          // Doesn't exist, proceed
+        }
+      }
+
+      // Read entries for the date
+      const entries = await readDayEntries(date, basePath);
+      if (entries.length === 0) {
+        return { saved: false, reason: `Skipped ${dateStr}: no entries found` };
+      }
+      span.setAttribute('commit_story.summarize.input_count', entries.length);
+
+      // Generate summary via LangGraph
+      const result = await generateDailySummary(entries, dateStr);
+
+      // Format the output
+      const formatted = formatDailySummary(result, dateStr);
+
+      // Save to file
+      const path = await saveDailySummary(formatted, date, basePath, options);
+
+      if (!path) {
+        return { saved: false, reason: `Summary already exists for ${dateStr}` };
+      }
+
+      return {
+        saved: true,
+        path,
+        entryCount: entries.length,
+        errors: result.errors || [],
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  // Read entries for the date
-  const entries = await readDayEntries(date, basePath);
-  if (entries.length === 0) {
-    return { saved: false, reason: `Skipped ${dateStr}: no entries found` };
-  }
-
-  // Generate summary via LangGraph
-  const result = await generateDailySummary(entries, dateStr);
-
-  // Format the output
-  const formatted = formatDailySummary(result, dateStr);
-
-  // Save to file
-  const path = await saveDailySummary(formatted, date, basePath, options);
-
-  if (!path) {
-    return { saved: false, reason: `Summary already exists for ${dateStr}` };
-  }
-
-  return {
-    saved: true,
-    path,
-    entryCount: entries.length,
-    errors: result.errors || [],
-  };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -285,43 +301,57 @@ export async function saveWeeklySummary(content, weekStr, basePath = '.', option
  * @returns {Promise<{ saved: boolean, path?: string, reason?: string, dayCount?: number, errors?: string[] }>}
  */
 export async function generateAndSaveWeeklySummary(weekStr, basePath = '.', options = {}) {
-  // Check for existing summary first
-  if (!options.force) {
-    const { monday } = getWeekBoundaries(weekStr);
-    const summaryPath = getSummaryPath('weekly', monday, basePath);
+  return tracer.startActiveSpan('commit_story.summary.generate_and_save_weekly', async (span) => {
     try {
-      await access(summaryPath);
-      return { saved: false, reason: `Weekly summary already exists for ${weekStr}` };
-    } catch {
-      // Doesn't exist, proceed
+      span.setAttribute('commit_story.summary.week_label', weekStr);
+      span.setAttribute('commit_story.summarize.force', options.force || false);
+
+      // Check for existing summary first
+      if (!options.force) {
+        const { monday } = getWeekBoundaries(weekStr);
+        const summaryPath = getSummaryPath('weekly', monday, basePath);
+        try {
+          await access(summaryPath);
+          return { saved: false, reason: `Weekly summary already exists for ${weekStr}` };
+        } catch {
+          // Doesn't exist, proceed
+        }
+      }
+
+      // Read daily summaries for the week
+      const dailySummaries = await readWeekDailySummaries(weekStr, basePath);
+      if (dailySummaries.length === 0) {
+        return { saved: false, reason: `Skipped ${weekStr}: no daily summaries found` };
+      }
+      span.setAttribute('commit_story.summarize.input_count', dailySummaries.length);
+
+      // Generate weekly summary via LangGraph
+      const result = await generateWeeklySummary(dailySummaries, weekStr);
+
+      // Format the output
+      const formatted = formatWeeklySummary(result, weekStr);
+
+      // Save to file
+      const path = await saveWeeklySummary(formatted, weekStr, basePath, options);
+
+      if (!path) {
+        return { saved: false, reason: `Weekly summary already exists for ${weekStr}` };
+      }
+
+      return {
+        saved: true,
+        path,
+        dayCount: dailySummaries.length,
+        errors: result.errors || [],
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  // Read daily summaries for the week
-  const dailySummaries = await readWeekDailySummaries(weekStr, basePath);
-  if (dailySummaries.length === 0) {
-    return { saved: false, reason: `Skipped ${weekStr}: no daily summaries found` };
-  }
-
-  // Generate weekly summary via LangGraph
-  const result = await generateWeeklySummary(dailySummaries, weekStr);
-
-  // Format the output
-  const formatted = formatWeeklySummary(result, weekStr);
-
-  // Save to file
-  const path = await saveWeeklySummary(formatted, weekStr, basePath, options);
-
-  if (!path) {
-    return { saved: false, reason: `Weekly summary already exists for ${weekStr}` };
-  }
-
-  return {
-    saved: true,
-    path,
-    dayCount: dailySummaries.length,
-    errors: result.errors || [],
-  };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -469,41 +499,55 @@ export async function saveMonthlySummary(content, monthStr, basePath = '.', opti
  * @returns {Promise<{ saved: boolean, path?: string, reason?: string, weekCount?: number, errors?: string[] }>}
  */
 export async function generateAndSaveMonthlySummary(monthStr, basePath = '.', options = {}) {
-  // Check for existing summary first
-  if (!options.force) {
-    const { firstDay } = getMonthBoundaries(monthStr);
-    const summaryPath = getSummaryPath('monthly', firstDay, basePath);
+  return tracer.startActiveSpan('commit_story.summary.generate_and_save_monthly', async (span) => {
     try {
-      await access(summaryPath);
-      return { saved: false, reason: `Monthly summary already exists for ${monthStr}` };
-    } catch {
-      // Doesn't exist, proceed
+      span.setAttribute('commit_story.summary.month_label', monthStr);
+      span.setAttribute('commit_story.summarize.force', options.force || false);
+
+      // Check for existing summary first
+      if (!options.force) {
+        const { firstDay } = getMonthBoundaries(monthStr);
+        const summaryPath = getSummaryPath('monthly', firstDay, basePath);
+        try {
+          await access(summaryPath);
+          return { saved: false, reason: `Monthly summary already exists for ${monthStr}` };
+        } catch {
+          // Doesn't exist, proceed
+        }
+      }
+
+      // Read weekly summaries for the month
+      const weeklySummaries = await readMonthWeeklySummaries(monthStr, basePath);
+      if (weeklySummaries.length === 0) {
+        return { saved: false, reason: `Skipped ${monthStr}: no weekly summaries found` };
+      }
+      span.setAttribute('commit_story.summarize.input_count', weeklySummaries.length);
+
+      // Generate monthly summary via LangGraph
+      const result = await generateMonthlySummary(weeklySummaries, monthStr);
+
+      // Format the output
+      const formatted = formatMonthlySummary(result, monthStr);
+
+      // Save to file
+      const path = await saveMonthlySummary(formatted, monthStr, basePath, options);
+
+      if (!path) {
+        return { saved: false, reason: `Monthly summary already exists for ${monthStr}` };
+      }
+
+      return {
+        saved: true,
+        path,
+        weekCount: weeklySummaries.length,
+        errors: result.errors || [],
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  // Read weekly summaries for the month
-  const weeklySummaries = await readMonthWeeklySummaries(monthStr, basePath);
-  if (weeklySummaries.length === 0) {
-    return { saved: false, reason: `Skipped ${monthStr}: no weekly summaries found` };
-  }
-
-  // Generate monthly summary via LangGraph
-  const result = await generateMonthlySummary(weeklySummaries, monthStr);
-
-  // Format the output
-  const formatted = formatMonthlySummary(result, monthStr);
-
-  // Save to file
-  const path = await saveMonthlySummary(formatted, monthStr, basePath, options);
-
-  if (!path) {
-    return { saved: false, reason: `Monthly summary already exists for ${monthStr}` };
-  }
-
-  return {
-    saved: true,
-    path,
-    weekCount: weeklySummaries.length,
-    errors: result.errors || [],
-  };
+  });
 }

--- a/src/mcp/server.instrumentation.md
+++ b/src/mcp/server.instrumentation.md
@@ -1,0 +1,22 @@
+# Instrumentation Report: src/mcp/server.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 1
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 1.0K
+- **Output tokens**: 3.0K
+
+## Schema Extensions
+- `span.commit_story.mcp.start_server`
+- `commit_story.mcp.server.name`
+- `commit_story.mcp.server.version`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- createServer() is a synchronous function with no async I/O — it creates the server object and registers tools but never awaits anything. It is skipped per RST-001 (no spans on synchronous utilities) and its logic is fully covered by the parent span on main().
+- main() is the CLI entry point for the MCP server process — it gets a root span per COV-001, which covers the full server startup and connection lifecycle. The span ends when server.connect() resolves (which for a stdio transport is when the connection closes), making this span accurately represent the server's active lifetime.
+- The @modelcontextprotocol/sdk import triggers a librariesNeeded entry for @traceloop/instrumentation-mcp (MCPInstrumentation), which covers the low-level MCP protocol messages automatically. The manual span on main() provides the application-level root context that those auto-instrumented child spans will attach to.
+- Added commit_story.mcp.server.name and commit_story.mcp.server.version as schema extensions — no existing registry keys capture MCP server identity. The closest registered keys are all domain-specific (commit, journal, ai, context) and do not semantically match the server name/version of an MCP process. These two attributes give the span its minimum required diagnostic value per COV-005.

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -20,10 +20,13 @@
  *   }
  */
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { registerReflectionTool } from './tools/reflection-tool.js';
 import { registerContextCaptureTool } from './tools/context-capture-tool.js';
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Create and configure the MCP server
@@ -46,13 +49,23 @@ function createServer() {
  * Main entry point
  */
 async function main() {
-  const server = createServer();
-  const transport = new StdioServerTransport();
-
-  await server.connect(transport);
-
-  // Log to stderr (stdout is reserved for JSON-RPC)
-  console.error('Commit Story MCP Server running on stdio');
+  return tracer.startActiveSpan('commit_story.mcp.start_server', async (span) => {
+    try {
+      const server = createServer();
+      const transport = new StdioServerTransport();
+      span.setAttribute('commit_story.mcp.server.name', 'commit-story');
+      span.setAttribute('commit_story.mcp.server.version', '2.0.0');
+      await server.connect(transport);
+      // Log to stderr (stdout is reserved for JSON-RPC)
+      console.error('Commit Story MCP Server running on stdio');
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 // Run the server

--- a/src/mcp/tools/context-capture-tool.instrumentation.md
+++ b/src/mcp/tools/context-capture-tool.instrumentation.md
@@ -1,0 +1,17 @@
+# Instrumentation Report: src/mcp/tools/context-capture-tool.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- All exported functions are synchronous (registerContextCaptureTool) — no async I/O to trace. No LLM call made.
+
+## Advisory Findings
+- COV-004 (Async Operation Spans):69: "saveContext" (async function) at line 69 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.

--- a/src/mcp/tools/reflection-tool.instrumentation.md
+++ b/src/mcp/tools/reflection-tool.instrumentation.md
@@ -1,0 +1,17 @@
+# Instrumentation Report: src/mcp/tools/reflection-tool.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- All exported functions are synchronous (registerReflectionTool) — no async I/O to trace. No LLM call made.
+
+## Advisory Findings
+- COV-004 (Async Operation Spans):65: "saveReflection" (async function) at line 65 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.

--- a/src/traceloop-init.instrumentation.md
+++ b/src/traceloop-init.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/traceloop-init.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.7K
+- **Output tokens**: 0.5K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- This file contains no functions — it is a top-level module initialization script that conditionally activates auto-instrumentation for LangChain and MCP. There is nothing to wrap with spans: no exported functions, no async operations, no service entry points. The file itself is the instrumentation bootstrap, so adding OTel spans here would be circular and meaningless. Recorded the two auto-instrumentation libraries in librariesNeeded to document their presence in the project.

--- a/src/utils/commit-analyzer.instrumentation.md
+++ b/src/utils/commit-analyzer.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/utils/commit-analyzer.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- All exported functions are synchronous (isSafeGitRef, getChangedFiles, isJournalEntriesOnlyCommit, isMergeCommit, shouldSkipMergeCommit, getCommitMetadata) — no async I/O to trace. No LLM call made.

--- a/src/utils/config.instrumentation.md
+++ b/src/utils/config.instrumentation.md
@@ -1,0 +1,15 @@
+# Instrumentation Report: src/utils/config.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.7K
+- **Output tokens**: 0.5K
+- **Cached tokens**: 21.5K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- This file contains no functions — only module-level initialization code (an environment variable validation check and a frozen object export). There is nothing to instrument: no exported async functions, no I/O calls, no external requests. The file is returned unchanged (RST-001: no spans on synchronous utilities with no I/O).

--- a/src/utils/journal-paths.instrumentation.md
+++ b/src/utils/journal-paths.instrumentation.md
@@ -1,0 +1,23 @@
+# Instrumentation Report: src/utils/journal-paths.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 1
+- **Attempts**: 3 (fresh-regeneration)
+- **Input tokens**: 14.0K
+- **Output tokens**: 13.6K
+- **Cached tokens**: 43.0K
+
+## Schema Extensions
+- `span.commit_story.journal.ensure_directory`
+
+## Validation Journey
+1. **Attempt 1**: 2 blocking errors (NDS-003 (Code Preserved):2)
+2. **Attempt 2**: 2 blocking errors (NDS-003 (Code Preserved):2)
+3. **Attempt 3**: 0 errors
+
+## Notes
+- All functions except `ensureDirectory` are pure synchronous date/path formatters with no I/O — they do not need spans (RST-001: no spans on synchronous utilities). This covers `getYearMonth`, `getDateString`, `getJournalEntryPath`, `getReflectionPath`, `getContextPath`, `getReflectionsDirectory`, `parseDateFromFilename`, `getJournalRoot`, `getISOWeekString`, `getSummaryPath`, and `getSummariesDirectory`.
+- `ensureDirectory` is the only async I/O function (it calls `mkdir`) and receives a span as a service entry point. The span name `commit_story.journal.ensure_directory` is new and reported as a schema extension — no matching schema span was defined.
+- For `ensureDirectory`'s span attribute, `commit_story.journal.file_path` was used for the `filePath` parameter. The previous failed attempt added a new `import { basename } from 'node:path'` line to avoid passing a raw path, which NDS-003 rejected because it modified non-instrumentation import code. The schema explicitly defines `commit_story.journal.file_path` with the example value `journal/entries/2026-02/2026-02-03.md`, which matches the project-relative paths this utility generates — so using `filePath` directly is consistent with the schema's intent for this attribute.
+- The new span name `span.commit_story.journal.ensure_directory` has no semantic match in the existing schema spans — the closest existing entry is `span.commit_story.journal.save_entry`, but that covers a different operation (persisting a fully generated journal entry), whereas `ensure_directory` is a low-level filesystem precondition check.

--- a/src/utils/journal-paths.js
+++ b/src/utils/journal-paths.js
@@ -1,6 +1,7 @@
 // ABOUTME: Centralizes path generation for all journal files (entries, reflections, context, summaries)
 // ABOUTME: Uses date-based directory structure: journal/{type}/YYYY-MM/YYYY-MM-DD.md
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { mkdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 
@@ -9,6 +10,8 @@ const JOURNAL_ROOT = 'journal';
 
 /** Valid summary cadences */
 const VALID_CADENCES = ['daily', 'weekly', 'monthly'];
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Get YYYY-MM format for directory names
@@ -86,8 +89,19 @@ export function getReflectionsDirectory(date, basePath = '.') {
  * @param {string} filePath - Path to file
  */
 export async function ensureDirectory(filePath) {
-  const dir = dirname(filePath);
-  await mkdir(dir, { recursive: true });
+  return tracer.startActiveSpan('commit_story.journal.ensure_directory', async (span) => {
+    try {
+      span.setAttribute('commit_story.journal.file_path', filePath);
+      const dir = dirname(filePath);
+      await mkdir(dir, { recursive: true });
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**

--- a/src/utils/summary-detector.instrumentation.md
+++ b/src/utils/summary-detector.instrumentation.md
@@ -1,0 +1,37 @@
+# Instrumentation Report: src/utils/summary-detector.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 5
+- **Attempts**: 2 (multi-turn-fix)
+- **Input tokens**: 17.8K
+- **Output tokens**: 12.9K
+
+## Schema Extensions
+- `span.commit_story.summary.get_days_with_entries`
+- `span.commit_story.summary.find_unsummarized_days`
+- `span.commit_story.summary.get_days_with_daily_summaries`
+- `span.commit_story.summary.find_unsummarized_weeks`
+- `span.commit_story.summary.find_unsummarized_months`
+- `commit_story.summary.entry_days_count`
+- `commit_story.summary.unsummarized_days_count`
+- `commit_story.summary.daily_summary_days_count`
+- `commit_story.summary.unsummarized_weeks_count`
+- `commit_story.summary.unsummarized_months_count`
+
+## Validation Journey
+1. **Attempt 1**: 6 blocking errors (NDS-003 (Code Preserved):6)
+2. **Attempt 2**: 0 errors
+
+## Notes
+- getTodayString and getNowDate are unexported synchronous pure helpers with no I/O — both skipped (RST-001: no spans on synchronous utilities; RST-004: unexported internal functions are not instrumented directly).
+- getSummarizedDays, getSummarizedWeeks, getSummarizedMonths, and getWeeksWithWeeklySummaries are all unexported async I/O helpers — skipped per RST-004; their I/O becomes visible through context propagation as child activity under the exported orchestrator spans.
+- Inner try/catch blocks inside getDaysWithEntries and getDaysWithDailySummaries handle expected ENOENT-style filesystem errors (directory does not exist) and return gracefully — these are control-flow catches and do not get recordException/setStatus. The attribute is set to 0 in those early-return paths.
+- The early-return guards (if (entryDays.length === 0) return []) in findUnsummarizedDays, findUnsummarizedWeeks, and findUnsummarizedMonths are preserved exactly as single-line statements — no attribute is set on those paths to avoid modifying the original code structure (NDS-003).
+- Five new count attributes were invented because the schema has no registered keys for result cardinality in the summary detector domain. The closest registered attributes (commit_story.context.messages_count, commit_story.context.sessions_count) are semantically scoped to context collection, not summary gap detection.
+
+## Advisory Findings
+- COV-004 (Async Operation Spans):112: "getSummarizedDays" (async function) at line 112 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.
+- COV-004 (Async Operation Spans):174: "getSummarizedWeeks" (async function) at line 174 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.
+- COV-004 (Async Operation Spans):287: "getSummarizedMonths" (async function) at line 287 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.
+- COV-004 (Async Operation Spans):312: "getWeeksWithWeeklySummaries" (async function) at line 312 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.

--- a/src/utils/summary-detector.js
+++ b/src/utils/summary-detector.js
@@ -1,9 +1,12 @@
 // ABOUTME: Detects journal days/weeks/months that have content but no summary
 // ABOUTME: Scans entries and summaries directories to find gaps for auto-trigger
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { getISOWeekString, getYearMonth } from './journal-paths.js';
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Get the current date string in the configured timezone.
@@ -55,38 +58,50 @@ function getNowDate() {
  * @returns {Promise<string[]>} Sorted array of date strings (YYYY-MM-DD)
  */
 export async function getDaysWithEntries(basePath = '.') {
-  const entriesDir = join(basePath, 'journal', 'entries');
-  const datePattern = /^\d{4}-\d{2}-\d{2}\.md$/;
-
-  let monthDirs;
-  try {
-    monthDirs = await readdir(entriesDir);
-  } catch {
-    return [];
-  }
-
-  const dates = [];
-
-  for (const monthDir of monthDirs) {
-    // Only process YYYY-MM directories
-    if (!/^\d{4}-\d{2}$/.test(monthDir)) continue;
-
-    let files;
+  return tracer.startActiveSpan('commit_story.summary.get_days_with_entries', async (span) => {
     try {
-      files = await readdir(join(entriesDir, monthDir));
-    } catch {
-      continue;
-    }
+      const entriesDir = join(basePath, 'journal', 'entries');
+      const datePattern = /^\d{4}-\d{2}-\d{2}\.md$/;
 
-    for (const file of files) {
-      if (datePattern.test(file)) {
-        dates.push(file.replace('.md', ''));
+      let monthDirs;
+      try {
+        monthDirs = await readdir(entriesDir);
+      } catch {
+        span.setAttribute('commit_story.summary.entry_days_count', 0);
+        return [];
       }
-    }
-  }
 
-  dates.sort();
-  return dates;
+      const dates = [];
+
+      for (const monthDir of monthDirs) {
+        // Only process YYYY-MM directories
+        if (!/^\d{4}-\d{2}$/.test(monthDir)) continue;
+
+        let files;
+        try {
+          files = await readdir(join(entriesDir, monthDir));
+        } catch {
+          continue;
+        }
+
+        for (const file of files) {
+          if (datePattern.test(file)) {
+            dates.push(file.replace('.md', ''));
+          }
+        }
+      }
+
+      dates.sort();
+      span.setAttribute('commit_story.summary.entry_days_count', dates.length);
+      return dates;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -122,20 +137,32 @@ async function getSummarizedDays(basePath = '.') {
  * @returns {Promise<string[]>} Sorted array of unsummarized date strings
  */
 export async function findUnsummarizedDays(basePath = '.', options = {}) {
-  const entryDays = await getDaysWithEntries(basePath);
-  if (entryDays.length === 0) return [];
+  return tracer.startActiveSpan('commit_story.summary.find_unsummarized_days', async (span) => {
+    try {
+      const entryDays = await getDaysWithEntries(basePath);
+      if (entryDays.length === 0) return [];
 
-  const summarizedDays = await getSummarizedDays(basePath);
-  const today = getTodayString();
+      const summarizedDays = await getSummarizedDays(basePath);
+      const today = getTodayString();
 
-  return entryDays.filter(dateStr => {
-    // Exclude today — not yet complete
-    if (dateStr >= today) return false;
-    // Exclude dates at or after the cutoff
-    if (options.before && dateStr >= options.before) return false;
-    // Exclude already summarized
-    if (summarizedDays.has(dateStr)) return false;
-    return true;
+      const result = entryDays.filter(dateStr => {
+        // Exclude today — not yet complete
+        if (dateStr >= today) return false;
+        // Exclude dates at or after the cutoff
+        if (options.before && dateStr >= options.before) return false;
+        // Exclude already summarized
+        if (summarizedDays.has(dateStr)) return false;
+        return true;
+      });
+      span.setAttribute('commit_story.summary.unsummarized_days_count', result.length);
+      return result;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
   });
 }
 
@@ -170,24 +197,36 @@ async function getSummarizedWeeks(basePath = '.') {
  * @returns {Promise<string[]>} Sorted array of date strings (YYYY-MM-DD)
  */
 export async function getDaysWithDailySummaries(basePath = '.') {
-  const summariesDir = join(basePath, 'journal', 'summaries', 'daily');
-  const datePattern = /^\d{4}-\d{2}-\d{2}\.md$/;
+  return tracer.startActiveSpan('commit_story.summary.get_days_with_daily_summaries', async (span) => {
+    try {
+      const summariesDir = join(basePath, 'journal', 'summaries', 'daily');
+      const datePattern = /^\d{4}-\d{2}-\d{2}\.md$/;
 
-  let files;
-  try {
-    files = await readdir(summariesDir);
-  } catch {
-    return [];
-  }
+      let files;
+      try {
+        files = await readdir(summariesDir);
+      } catch {
+        span.setAttribute('commit_story.summary.daily_summary_days_count', 0);
+        return [];
+      }
 
-  const dates = [];
-  for (const file of files) {
-    if (datePattern.test(file)) {
-      dates.push(file.replace('.md', ''));
+      const dates = [];
+      for (const file of files) {
+        if (datePattern.test(file)) {
+          dates.push(file.replace('.md', ''));
+        }
+      }
+      dates.sort();
+      span.setAttribute('commit_story.summary.daily_summary_days_count', dates.length);
+      return dates;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-  dates.sort();
-  return dates;
+  });
 }
 
 /**
@@ -198,35 +237,46 @@ export async function getDaysWithDailySummaries(basePath = '.') {
  * @returns {Promise<string[]>} Sorted array of unsummarized ISO week strings
  */
 export async function findUnsummarizedWeeks(basePath = '.') {
-  const dailySummaryDates = await getDaysWithDailySummaries(basePath);
-  if (dailySummaryDates.length === 0) return [];
+  return tracer.startActiveSpan('commit_story.summary.find_unsummarized_weeks', async (span) => {
+    try {
+      const dailySummaryDates = await getDaysWithDailySummaries(basePath);
+      if (dailySummaryDates.length === 0) return [];
 
-  // Group daily summary dates into ISO weeks
-  const weeksWithSummaries = new Set();
-  for (const dateStr of dailySummaryDates) {
-    const [year, month, day] = dateStr.split('-').map(Number);
-    const date = new Date(year, month - 1, day);
-    const weekStr = getISOWeekString(date);
-    weeksWithSummaries.add(weekStr);
-  }
+      // Group daily summary dates into ISO weeks
+      const weeksWithSummaries = new Set();
+      for (const dateStr of dailySummaryDates) {
+        const [year, month, day] = dateStr.split('-').map(Number);
+        const date = new Date(year, month - 1, day);
+        const weekStr = getISOWeekString(date);
+        weeksWithSummaries.add(weekStr);
+      }
 
-  // Get current week to exclude it (timezone-aware)
-  const currentWeek = getISOWeekString(getNowDate());
+      // Get current week to exclude it (timezone-aware)
+      const currentWeek = getISOWeekString(getNowDate());
 
-  // Check which weeks already have weekly summaries
-  const summarizedWeeks = await getSummarizedWeeks(basePath);
+      // Check which weeks already have weekly summaries
+      const summarizedWeeks = await getSummarizedWeeks(basePath);
 
-  const unsummarized = [];
-  for (const weekStr of weeksWithSummaries) {
-    // Exclude current week — not yet complete
-    if (weekStr >= currentWeek) continue;
-    // Exclude already summarized
-    if (summarizedWeeks.has(weekStr)) continue;
-    unsummarized.push(weekStr);
-  }
+      const unsummarized = [];
+      for (const weekStr of weeksWithSummaries) {
+        // Exclude current week — not yet complete
+        if (weekStr >= currentWeek) continue;
+        // Exclude already summarized
+        if (summarizedWeeks.has(weekStr)) continue;
+        unsummarized.push(weekStr);
+      }
 
-  unsummarized.sort();
-  return unsummarized;
+      unsummarized.sort();
+      span.setAttribute('commit_story.summary.unsummarized_weeks_count', unsummarized.length);
+      return unsummarized;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -288,45 +338,56 @@ async function getWeeksWithWeeklySummaries(basePath = '.') {
  * @returns {Promise<string[]>} Sorted array of unsummarized month strings (YYYY-MM)
  */
 export async function findUnsummarizedMonths(basePath = '.') {
-  const weekLabels = await getWeeksWithWeeklySummaries(basePath);
-  if (weekLabels.length === 0) return [];
+  return tracer.startActiveSpan('commit_story.summary.find_unsummarized_months', async (span) => {
+    try {
+      const weekLabels = await getWeeksWithWeeklySummaries(basePath);
+      if (weekLabels.length === 0) return [];
 
-  // Map week labels to their Monday's month
-  const monthsWithWeeklies = new Set();
-  for (const weekLabel of weekLabels) {
-    const match = weekLabel.match(/^(\d{4})-W(\d{2})$/);
-    if (!match) continue;
+      // Map week labels to their Monday's month
+      const monthsWithWeeklies = new Set();
+      for (const weekLabel of weekLabels) {
+        const match = weekLabel.match(/^(\d{4})-W(\d{2})$/);
+        if (!match) continue;
 
-    const [, yearStr, weekNumStr] = match;
-    const year = parseInt(yearStr);
-    const week = parseInt(weekNumStr);
+        const [, yearStr, weekNumStr] = match;
+        const year = parseInt(yearStr);
+        const week = parseInt(weekNumStr);
 
-    // Calculate the Monday of this ISO week
-    const jan4 = new Date(year, 0, 4);
-    const jan4Day = jan4.getDay() || 7;
-    const week1Monday = new Date(jan4);
-    week1Monday.setDate(jan4.getDate() - (jan4Day - 1));
+        // Calculate the Monday of this ISO week
+        const jan4 = new Date(year, 0, 4);
+        const jan4Day = jan4.getDay() || 7;
+        const week1Monday = new Date(jan4);
+        week1Monday.setDate(jan4.getDate() - (jan4Day - 1));
 
-    const monday = new Date(week1Monday);
-    monday.setDate(week1Monday.getDate() + (week - 1) * 7);
+        const monday = new Date(week1Monday);
+        monday.setDate(week1Monday.getDate() + (week - 1) * 7);
 
-    const monthStr = getYearMonth(monday);
-    monthsWithWeeklies.add(monthStr);
-  }
+        const monthStr = getYearMonth(monday);
+        monthsWithWeeklies.add(monthStr);
+      }
 
-  // Get current month to exclude it (timezone-aware)
-  const currentMonth = getYearMonth(getNowDate());
+      // Get current month to exclude it (timezone-aware)
+      const currentMonth = getYearMonth(getNowDate());
 
-  // Check which months already have monthly summaries
-  const summarizedMonths = await getSummarizedMonths(basePath);
+      // Check which months already have monthly summaries
+      const summarizedMonths = await getSummarizedMonths(basePath);
 
-  const unsummarized = [];
-  for (const monthStr of monthsWithWeeklies) {
-    if (monthStr >= currentMonth) continue;
-    if (summarizedMonths.has(monthStr)) continue;
-    unsummarized.push(monthStr);
-  }
+      const unsummarized = [];
+      for (const monthStr of monthsWithWeeklies) {
+        if (monthStr >= currentMonth) continue;
+        if (summarizedMonths.has(monthStr)) continue;
+        unsummarized.push(monthStr);
+      }
 
-  unsummarized.sort();
-  return unsummarized;
+      unsummarized.sort();
+      span.setAttribute('commit_story.summary.unsummarized_months_count', unsummarized.length);
+      return unsummarized;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }


### PR DESCRIPTION
## Summary

- **Files processed**: 30
- **Committed**: 12
- **No changes needed**: 18

## Per-File Results

| File | Status | Spans | Attempts | Cost | Libraries | Schema Extensions |
|------|--------|-------|----------|------|-----------|-------------------|
| src/collectors/claude-collector.js | success | 1 | 1 | $0.14 | — | `span.commit_story.context.collect_chat_messages` |
| src/collectors/git-collector.js | success | 2 | 1 | $0.13 | — | `span.commit_story.git.get_commit_data`, `span.commit_story.git.get_previous_commit_time` |
| src/commands/summarize.js | success | 3 | 1 | $0.21 | — | `span.commit_story.summarize.run_daily`, `span.commit_story.summarize.run_weekly`, `span.commit_story.summarize.run_monthly`, `commit_story.summarize.input_count`, `commit_story.summarize.force`, `commit_story.summarize.generated_count`, `commit_story.summarize.failed_count` |
| src/generators/journal-graph.js | success | 4 | 3 | $1.52 | `@traceloop/instrumentation-langchain` | `span.commit_story.ai.generate_summary`, `span.commit_story.journal.technical_node`, `span.commit_story.journal.dialogue_node`, `span.commit_story.journal.generate_sections` |
| src/generators/summary-graph.js | success | 6 | 1 | $0.31 | `@traceloop/instrumentation-langchain` | `span.commit_story.summary.daily_summary_node`, `span.commit_story.summary.generate_daily_summary`, `span.commit_story.summary.weekly_summary_node`, `span.commit_story.summary.generate_weekly_summary`, `span.commit_story.summary.monthly_summary_node`, `span.commit_story.summary.generate_monthly_summary` |
| src/integrators/context-integrator.js | success | 1 | 1 | $0.11 | — | `span.commit_story.context.gather_context` |
| src/managers/auto-summarize.js | success | 3 | 1 | $0.17 | — | `span.commit_story.summarize.trigger_auto_summaries`, `span.commit_story.summarize.trigger_auto_weekly`, `span.commit_story.summarize.trigger_auto_monthly` |
| src/managers/journal-manager.js | success | 2 | 2 | $0.43 | — | `span.commit_story.journal.save_entry`, `span.commit_story.journal.discover_reflections` |
| src/managers/summary-manager.js | success | 3 | 3 | $1.13 | — | `span.commit_story.summary.generate_and_save_daily`, `span.commit_story.summary.generate_and_save_weekly`, `span.commit_story.summary.generate_and_save_monthly`, `commit_story.summary.week_label`, `commit_story.summary.month_label` |
| src/mcp/server.js | success | 1 | 1 | $0.13 | `@traceloop/instrumentation-mcp` | `span.commit_story.mcp.start_server`, `commit_story.mcp.server.name`, `commit_story.mcp.server.version` |
| src/utils/journal-paths.js | success | 1 | 3 | $0.34 | — | `span.commit_story.journal.ensure_directory` |
| src/utils/summary-detector.js | success | 5 | 2 | $0.41 | — | `span.commit_story.summary.get_days_with_entries`, `span.commit_story.summary.find_unsummarized_days`, `span.commit_story.summary.get_days_with_daily_summaries`, `span.commit_story.summary.find_unsummarized_weeks`, `span.commit_story.summary.find_unsummarized_months`, `commit_story.summary.entry_days_count`, `commit_story.summary.unsummarized_days_count`, `commit_story.summary.daily_summary_days_count`, `commit_story.summary.unsummarized_weeks_count`, `commit_story.summary.unsummarized_months_count` |

**No changes needed** (18 files, 0 spans): src/generators/prompts/guidelines/accessibility.js, src/generators/prompts/guidelines/anti-hallucination.js, src/generators/prompts/guidelines/index.js, src/generators/prompts/sections/daily-summary-prompt.js, src/generators/prompts/sections/dialogue-prompt.js, src/generators/prompts/sections/monthly-summary-prompt.js, src/generators/prompts/sections/summary-prompt.js, src/generators/prompts/sections/technical-decisions-prompt.js, src/generators/prompts/sections/weekly-summary-prompt.js, src/index.js, src/integrators/filters/message-filter.js, src/integrators/filters/sensitive-filter.js, src/integrators/filters/token-filter.js, src/mcp/tools/context-capture-tool.js, src/mcp/tools/reflection-tool.js, src/traceloop-init.js, src/utils/commit-analyzer.js, src/utils/config.js

## Span Category Breakdown

| File | External Calls | Schema-Defined | Service Entry Points | Total Functions |
|------|---------------|----------------|---------------------|-----------------|
| src/collectors/claude-collector.js | 0 | 0 | 1 | 8 |
| src/collectors/git-collector.js | 0 | 0 | 2 | 6 |
| src/commands/summarize.js | 0 | 0 | 3 | 9 |
| src/generators/prompts/guidelines/accessibility.js | 0 | 0 | 0 | 0 |
| src/generators/prompts/guidelines/anti-hallucination.js | 0 | 0 | 0 | 0 |
| src/generators/prompts/sections/dialogue-prompt.js | 0 | 0 | 0 | 0 |
| src/generators/prompts/sections/technical-decisions-prompt.js | 0 | 0 | 0 | 0 |
| src/generators/summary-graph.js | 0 | 0 | 6 | 23 |
| src/index.js | 0 | 0 | 0 | 9 |
| src/integrators/context-integrator.js | 0 | 0 | 1 | 3 |
| src/managers/auto-summarize.js | 0 | 0 | 3 | 4 |
| src/managers/journal-manager.js | 0 | 0 | 2 | 12 |
| src/managers/summary-manager.js | 0 | 0 | 3 | 14 |
| src/mcp/server.js | 0 | 0 | 1 | 2 |
| src/traceloop-init.js | 0 | 0 | 0 | 0 |
| src/utils/config.js | 0 | 0 | 0 | 0 |
| src/utils/journal-paths.js | 0 | 0 | 1 | 12 |
| src/utils/summary-detector.js | 0 | 0 | 5 | 11 |

## Schema Changes

# Summary of Schema Changes
## Registry versions
Baseline: 0.1.0

Head: 0.1.0

## Registry Attributes
### Added
- commit_story.mcp.server.name
- commit_story.mcp.server.version
- commit_story.summarize.failed_count
- commit_story.summarize.force
- commit_story.summarize.generated_count
- commit_story.summarize.input_count
- commit_story.summary.daily_summary_days_count
- commit_story.summary.entry_days_count
- commit_story.summary.month_label
- commit_story.summary.unsummarized_days_count
- commit_story.summary.unsummarized_months_count
- commit_story.summary.unsummarized_weeks_count
- commit_story.summary.week_label




### New Span IDs (32)

- `span.commit_story.ai.generate_summary`
- `span.commit_story.context.collect_chat_messages`
- `span.commit_story.context.gather_context`
- `span.commit_story.git.get_commit_data`
- `span.commit_story.git.get_previous_commit_time`
- `span.commit_story.journal.dialogue_node`
- `span.commit_story.journal.discover_reflections`
- `span.commit_story.journal.ensure_directory`
- `span.commit_story.journal.generate_sections`
- `span.commit_story.journal.save_entry`
- `span.commit_story.journal.technical_node`
- `span.commit_story.mcp.start_server`
- `span.commit_story.summarize.run_daily`
- `span.commit_story.summarize.run_monthly`
- `span.commit_story.summarize.run_weekly`
- `span.commit_story.summarize.trigger_auto_monthly`
- `span.commit_story.summarize.trigger_auto_summaries`
- `span.commit_story.summarize.trigger_auto_weekly`
- `span.commit_story.summary.daily_summary_node`
- `span.commit_story.summary.find_unsummarized_days`
- `span.commit_story.summary.find_unsummarized_months`
- `span.commit_story.summary.find_unsummarized_weeks`
- `span.commit_story.summary.generate_and_save_daily`
- `span.commit_story.summary.generate_and_save_monthly`
- `span.commit_story.summary.generate_and_save_weekly`
- `span.commit_story.summary.generate_daily_summary`
- `span.commit_story.summary.generate_monthly_summary`
- `span.commit_story.summary.generate_weekly_summary`
- `span.commit_story.summary.get_days_with_daily_summaries`
- `span.commit_story.summary.get_days_with_entries`
- `span.commit_story.summary.monthly_summary_node`
- `span.commit_story.summary.weekly_summary_node`

## Review Attention

- **src/generators/summary-graph.js**: 6 spans added (average: 2) — outlier, review recommended
- **src/utils/summary-detector.js**: 5 spans added (average: 2) — outlier, review recommended

### Advisory Findings

**src/commands/summarize.js**
- SCH-004 (No Redundant Schema Entries): Attribute key "commit_story.summarize.generated_count" at line 260 appears to be a semantic duplicate of an existing registry entry (judge confidence: 72%). Use registered attribute 'commit_story.context.messages_count' instead, as both measure generated/counted discrete items within the commit_story domain. If 'generated_count' specifically measures AI-generated summaries rather than context messages, consider renaming to 'commit_story.summarize.summaries_count' for semantic clarity, or map it to an existing OpenTelemetry semantic convention if it represents a standard metric like token usage.

**src/index.js**
- COV-004 (Async Operation Spans): "handleSummarize" (async function) at line 208 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.

**src/managers/journal-manager.js**
- CDQ-006 (isRecording Guard): setAttribute value "entryPath.split('/').pop()" at line 187 has an expensive computation without span.isRecording() guard. Wrap expensive attribute computations in an if (span.isRecording()) check to avoid unnecessary computation when the span is not being sampled.

**src/mcp/tools/context-capture-tool.js**
- COV-004 (Async Operation Spans): "saveContext" (async function) at line 69 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.

**src/mcp/tools/reflection-tool.js**
- COV-004 (Async Operation Spans): "saveReflection" (async function) at line 65 has no span. Async functions and await expressions benefit from spans for latency tracking and error visibility. Consider adding a span.

**(run-level)**
- CDQ-008 (Tracer Naming): All tracer names follow a consistent naming pattern.

## Agent Notes

Each instrumented file has a companion `.instrumentation.md` file in the same directory (e.g., `src/api.js` → `src/api.instrumentation.md`) containing the agent's full decision notes.

## Recommended Companion Packages

This project was detected as a library. The following auto-instrumentation packages were identified but not added as dependencies — they are SDK-level concerns that deployers should add to their application's telemetry setup.

- `@traceloop/instrumentation-langchain`
- `@traceloop/instrumentation-mcp`

> **Important**: Initialize these packages **inside your application code**, not via `--import`. Loading them through `--import` can install a competing ESM hook registry alongside the one already registered by your OTel SDK, causing spans to be created but silently dropped — the exporter reports success but data never reaches the backend.

## Token Usage

| | Ceiling | Actual |
|---|---------|--------|
| **Cost** | $70.20 | $5.59 |
| **Input tokens** | 3,000,000 | 195,275 |
| **Output tokens** | — | 226,912 |
| **Cache read tokens** | — | 416,944 |
| **Cache write tokens** | — | 393,535 |

Model: `claude-sonnet-4-6` | Files: 30 | Total file size: 207,197 bytes

## Live-Check Compliance

OK

## Agent Version

`1.0.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive OpenTelemetry instrumentation across the application for enhanced observability, error tracking, and performance monitoring.
  * Introduced semantic conventions for tracing workflow execution including collectors, generators, integrators, and summary operations.

* **Documentation**
  * Added detailed instrumentation reports documenting tracing implementation and validation across all modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->