### PR TITLE
fix: add service.instance.id to OTel bootstrap resource

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,9 @@ Entry format: `- (YYYY-MM-DD) Description of feature-level change (PRD #X, miles
 
 ## [Unreleased]
 
+### Fixed
+- (2026-05-05) Added `service.instance.id: randomUUID()` to `resourceFromAttributes` in `examples/instrumentation.js` so RES-001 passes in IS scoring runs.
+
 ### Added
 - (2026-03-21) Installed OTel SDK, OTLP exporter, and Traceloop auto-instrumentation packages for local telemetry (PRD #51, milestone 1)
 - (2026-03-21) Created OTel SDK bootstrap with OTLP exporter, resource attributes, LangChain/MCP auto-instrumentation, and graceful shutdown (PRD #51, milestone 2)

--- a/examples/instrumentation.js
+++ b/examples/instrumentation.js
@@ -5,6 +5,7 @@ import { NodeSDK } from '@opentelemetry/sdk-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { resourceFromAttributes } from '@opentelemetry/resources';
+import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -30,6 +31,7 @@ const sdk = new NodeSDK({
     'service.name': 'commit-story',
     'service.version': pkg.version,
     'deployment.environment': process.env.NODE_ENV || 'development',
+    'service.instance.id': randomUUID(),
   }),
   // SimpleSpanProcessor exports each span immediately on span.end() — better
   // for CLI apps where process.exit() can kill the event loop before a


### PR DESCRIPTION
Adds `service.instance.id: randomUUID()` to `resourceFromAttributes` in `examples/instrumentation.js` so RES-001 passes in IS scoring runs.

This fix was identified during spinybacked-orbweaver-eval run-3 (IS score 80/100) — `service.instance.id` was absent from the bootstrap resource, causing a 10-point IS miss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Each process instance now reports a unique service instance identifier to improve observability and instrumentation tracking.

* **Documentation**
  * Progress log updated to record the change and its verification for scoring/audit purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->