### PR TITLE
Add messages_filtered and substantial_messages to context attribute group

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,6 +10,7 @@ Entry format: `- (YYYY-MM-DD) Description of feature-level change (PRD #X, miles
 - (2026-05-05) Added `service.instance.id: randomUUID()` to `resourceFromAttributes` in `examples/instrumentation.js` so RES-001 passes in IS scoring runs.
 
 ### Added
+- (2026-06-16) Added `commit_story.context.messages_filtered` and `commit_story.context.substantial_messages` to the Weaver registry context attribute group. These two attributes support the traces-to-logs correlation demo: `messages_filtered` captures how many messages were dropped as noise during context collection, and `substantial_messages` tracks how many were substantive enough to gate whether the `dialogue` and `technical_decisions` journal sections run. Both are emitted in structured log bodies alongside the LLM generation span to give the log line context color beyond just trace correlation.
 - (2026-03-21) Installed OTel SDK, OTLP exporter, and Traceloop auto-instrumentation packages for local telemetry (PRD #51, milestone 1)
 - (2026-03-21) Created OTel SDK bootstrap with OTLP exporter, resource attributes, LangChain/MCP auto-instrumentation, and graceful shutdown (PRD #51, milestone 2)
 - (2026-03-21) Added Datadog Agent Docker setup/teardown scripts with vals-based secret injection and port/container safety checks (PRD #51, milestone 3)

--- a/telemetry/registry/attributes.yaml
+++ b/telemetry/registry/attributes.yaml
@@ -73,6 +73,22 @@ groups:
           - 42
           - 156
 
+      - id: commit_story.context.messages_filtered
+        type: int
+        stability: development
+        brief: Number of messages dropped during filtering (tool calls, noise, too short, etc.)
+        examples:
+          - 12
+          - 38
+
+      - id: commit_story.context.substantial_messages
+        type: int
+        stability: development
+        brief: Number of substantive user messages (>=50 chars, not simple commands); gates whether dialogue and technical_decisions sections run
+        examples:
+          - 31
+          - 8
+
       - id: commit_story.context.time_window_start
         type: string
         stability: development


### PR DESCRIPTION
## Summary

- Adds `commit_story.context.messages_filtered` to the Weaver registry context group — the number of messages dropped during filtering (tool calls, noise, too short, etc.)
- Adds `commit_story.context.substantial_messages` to the Weaver registry context group — the number of substantive user messages (≥50 chars, not simple commands) that gate whether the `dialogue` and `technical_decisions` journal sections run

## Why

These two attributes are needed for the traces-to-logs correlation demo (tracked in [spinybacked-orbweaver issue #966](https://github.com/wiggitywhitney/spinybacked-orbweaver/issues/966)). The demo shows `commit_story.ai.section_type` as an attribute that appears consistently across spans, metric dimensions, and structured log bodies — demonstrating the observability triangle. The message count attributes give the log line context color beyond just trace correlation: how many messages were captured, how many were noise, how many were substantial enough to drive content decisions.

## Test plan

- [ ] `weaver registry check` passes with the new attribute definitions
- [ ] Both attributes have correct type (`int`), stability (`development`), brief descriptions, and examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new telemetry metrics to enhance visibility into message processing workflows
  * Added metrics that capture filtered message activity and substantive message counts
  * These metrics enable improved correlation between system execution traces and application logs for better diagnostics

* **Documentation**
  * Updated progress tracking documentation with specifications for new telemetry attributes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->