### PR TITLE
Add OpenTelemetry instrumentation (31 files)

### DIFF
--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -122,3 +122,8 @@ groups:
     stability: development
     brief: "Agent-discovered span: commit_story.context.gather_context"
     span_kind: internal
+  - id: span.commit_story.context.save_context
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.context.save_context"
+    span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -141,3 +141,13 @@ groups:
     stability: development
     brief: "Agent-discovered span: commit_story.journal.ensure_directory"
     span_kind: internal
+  - id: span.commit_story.journal.save_entry
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.save_entry"
+    span_kind: internal
+  - id: span.commit_story.journal.discover_reflections
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.discover_reflections"
+    span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -16,6 +16,22 @@ groups:
         type: int
         stability: development
         brief: "Agent-discovered attribute: commit_story.git.parent_count"
+      - id: commit_story.journal.entries_count
+        type: int
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.journal.entries_count"
+      - id: commit_story.journal.week_label
+        type: string
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.journal.week_label"
+      - id: commit_story.journal.month_label
+        type: string
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.journal.month_label"
+      - id: commit_story.journal.summaries_count
+        type: int
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.journal.summaries_count"
   - id: span.commit_story.context.collect_messages
     type: span
     stability: development
@@ -70,4 +86,34 @@ groups:
     type: span
     stability: development
     brief: "Agent-discovered span: commit_story.journal.generate_sections"
+    span_kind: internal
+  - id: span.commit_story.journal.daily_summary_node
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.daily_summary_node"
+    span_kind: internal
+  - id: span.commit_story.journal.generate_daily_summary
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.generate_daily_summary"
+    span_kind: internal
+  - id: span.commit_story.journal.weekly_summary_node
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.weekly_summary_node"
+    span_kind: internal
+  - id: span.commit_story.journal.generate_weekly_summary
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.generate_weekly_summary"
+    span_kind: internal
+  - id: span.commit_story.journal.monthly_summary_node
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.monthly_summary_node"
+    span_kind: internal
+  - id: span.commit_story.journal.generate_monthly_summary
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.generate_monthly_summary"
     span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -283,3 +283,20 @@ groups:
     stability: development
     brief: "Agent-discovered span: commit_story.journal.find_unsummarized_months"
     span_kind: internal
+  - id: span.commit_story.commands.trigger_auto_summaries
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.commands.trigger_auto_summaries"
+    span_kind: internal
+  - id: span.commit_story.commands.trigger_auto_weekly_summaries
+    type: span
+    stability: development
+    brief: "Agent-discovered span:
+      commit_story.commands.trigger_auto_weekly_summaries"
+    span_kind: internal
+  - id: span.commit_story.commands.trigger_auto_monthly_summaries
+    type: span
+    stability: development
+    brief: "Agent-discovered span:
+      commit_story.commands.trigger_auto_monthly_summaries"
+    span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -32,6 +32,10 @@ groups:
         type: int
         stability: development
         brief: "Agent-discovered attribute: commit_story.journal.summaries_count"
+      - id: commit_story.mcp.transport_type
+        type: string
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.mcp.transport_type"
   - id: span.commit_story.context.collect_messages
     type: span
     stability: development
@@ -126,4 +130,9 @@ groups:
     type: span
     stability: development
     brief: "Agent-discovered span: commit_story.context.save_context"
+    span_kind: internal
+  - id: span.commit_story.mcp.main
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.mcp.main"
     span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -44,6 +44,21 @@ groups:
         type: boolean
         stability: development
         brief: "Agent-discovered attribute: commit_story.commands.force"
+      - id: commit_story.journal.unsummarized_days_count
+        type: int
+        stability: development
+        brief: "Agent-discovered attribute:
+          commit_story.journal.unsummarized_days_count"
+      - id: commit_story.journal.unsummarized_weeks_count
+        type: int
+        stability: development
+        brief: "Agent-discovered attribute:
+          commit_story.journal.unsummarized_weeks_count"
+      - id: commit_story.journal.unsummarized_months_count
+        type: int
+        stability: development
+        brief: "Agent-discovered attribute:
+          commit_story.journal.unsummarized_months_count"
   - id: span.commit_story.context.collect_messages
     type: span
     stability: development
@@ -221,4 +236,50 @@ groups:
     type: span
     stability: development
     brief: "Agent-discovered span: commit_story.commands.run_monthly_summarize"
+    span_kind: internal
+  - id: span.commit_story.journal.get_days_with_entries
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.get_days_with_entries"
+    span_kind: internal
+  - id: span.commit_story.journal.get_summarized_days
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.get_summarized_days"
+    span_kind: internal
+  - id: span.commit_story.journal.find_unsummarized_days
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.find_unsummarized_days"
+    span_kind: internal
+  - id: span.commit_story.journal.get_summarized_weeks
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.get_summarized_weeks"
+    span_kind: internal
+  - id: span.commit_story.journal.get_days_with_daily_summaries
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.get_days_with_daily_summaries"
+    span_kind: internal
+  - id: span.commit_story.journal.find_unsummarized_weeks
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.find_unsummarized_weeks"
+    span_kind: internal
+  - id: span.commit_story.journal.get_summarized_months
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.get_summarized_months"
+    span_kind: internal
+  - id: span.commit_story.journal.get_weeks_with_weekly_summaries
+    type: span
+    stability: development
+    brief: "Agent-discovered span:
+      commit_story.journal.get_weeks_with_weekly_summaries"
+    span_kind: internal
+  - id: span.commit_story.journal.find_unsummarized_months
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.find_unsummarized_months"
     span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -1,6 +1,53 @@
 groups:
+  - id: registry.commit_story.agent_extensions
+    type: attribute_group
+    display_name: Agent-Created Attributes
+    brief: Attributes created by the instrumentation agent
+    attributes:
+      - id: commit_story.git.subcommand
+        type: string
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.git.subcommand"
+      - id: commit_story.git.diff_lines
+        type: string
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.git.diff_lines"
+      - id: commit_story.git.parent_count
+        type: int
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.git.parent_count"
   - id: span.commit_story.context.collect_messages
     type: span
     stability: development
     brief: "Agent-discovered span: commit_story.context.collect_messages"
+    span_kind: internal
+  - id: span.commit_story.git.run
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.git.run"
+    span_kind: internal
+  - id: span.commit_story.git.commit_metadata
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.git.commit_metadata"
+    span_kind: internal
+  - id: span.commit_story.git.commit_diff
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.git.commit_diff"
+    span_kind: internal
+  - id: span.commit_story.git.merge_info
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.git.merge_info"
+    span_kind: internal
+  - id: span.commit_story.git.get_previous_commit_time
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.git.get_previous_commit_time"
+    span_kind: internal
+  - id: span.commit_story.git.get_commit_data
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.git.get_commit_data"
     span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -151,3 +151,51 @@ groups:
     stability: development
     brief: "Agent-discovered span: commit_story.journal.discover_reflections"
     span_kind: internal
+  - id: span.commit_story.journal.read_day_entries
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.read_day_entries"
+    span_kind: internal
+  - id: span.commit_story.journal.save_daily_summary
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.save_daily_summary"
+    span_kind: internal
+  - id: span.commit_story.journal.generate_and_save_daily_summary
+    type: span
+    stability: development
+    brief: "Agent-discovered span:
+      commit_story.journal.generate_and_save_daily_summary"
+    span_kind: internal
+  - id: span.commit_story.journal.read_week_daily_summaries
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.read_week_daily_summaries"
+    span_kind: internal
+  - id: span.commit_story.journal.save_weekly_summary
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.save_weekly_summary"
+    span_kind: internal
+  - id: span.commit_story.journal.generate_and_save_weekly_summary
+    type: span
+    stability: development
+    brief: "Agent-discovered span:
+      commit_story.journal.generate_and_save_weekly_summary"
+    span_kind: internal
+  - id: span.commit_story.journal.read_month_weekly_summaries
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.read_month_weekly_summaries"
+    span_kind: internal
+  - id: span.commit_story.journal.save_monthly_summary
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.save_monthly_summary"
+    span_kind: internal
+  - id: span.commit_story.journal.generate_and_save_monthly_summary
+    type: span
+    stability: development
+    brief: "Agent-discovered span:
+      commit_story.journal.generate_and_save_monthly_summary"
+    span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -51,3 +51,23 @@ groups:
     stability: development
     brief: "Agent-discovered span: commit_story.git.get_commit_data"
     span_kind: internal
+  - id: span.commit_story.journal.generate_summary
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.generate_summary"
+    span_kind: internal
+  - id: span.commit_story.journal.generate_technical
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.generate_technical"
+    span_kind: internal
+  - id: span.commit_story.journal.generate_dialogue
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.generate_dialogue"
+    span_kind: internal
+  - id: span.commit_story.journal.generate_sections
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.generate_sections"
+    span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -117,3 +117,8 @@ groups:
     stability: development
     brief: "Agent-discovered span: commit_story.journal.generate_monthly_summary"
     span_kind: internal
+  - id: span.commit_story.context.gather_context
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.context.gather_context"
+    span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -300,3 +300,8 @@ groups:
     brief: "Agent-discovered span:
       commit_story.commands.trigger_auto_monthly_summaries"
     span_kind: internal
+  - id: span.commit_story.cli.main
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.cli.main"
+    span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -1,0 +1,6 @@
+groups:
+  - id: span.commit_story.context.collect_messages
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.context.collect_messages"
+    span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -36,6 +36,14 @@ groups:
         type: string
         stability: development
         brief: "Agent-discovered attribute: commit_story.mcp.transport_type"
+      - id: commit_story.commands.dates_count
+        type: int
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.commands.dates_count"
+      - id: commit_story.commands.force
+        type: boolean
+        stability: development
+        brief: "Agent-discovered attribute: commit_story.commands.force"
   - id: span.commit_story.context.collect_messages
     type: span
     stability: development
@@ -198,4 +206,19 @@ groups:
     stability: development
     brief: "Agent-discovered span:
       commit_story.journal.generate_and_save_monthly_summary"
+    span_kind: internal
+  - id: span.commit_story.commands.run_summarize
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.commands.run_summarize"
+    span_kind: internal
+  - id: span.commit_story.commands.run_weekly_summarize
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.commands.run_weekly_summarize"
+    span_kind: internal
+  - id: span.commit_story.commands.run_monthly_summarize
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.commands.run_monthly_summarize"
     span_kind: internal

--- a/semconv/agent-extensions.yaml
+++ b/semconv/agent-extensions.yaml
@@ -136,3 +136,8 @@ groups:
     stability: development
     brief: "Agent-discovered span: commit_story.mcp.main"
     span_kind: internal
+  - id: span.commit_story.journal.ensure_directory
+    type: span
+    stability: development
+    brief: "Agent-discovered span: commit_story.journal.ensure_directory"
+    span_kind: internal

--- a/spiny-orb-pr-summary.md
+++ b/spiny-orb-pr-summary.md
@@ -1,0 +1,287 @@
+## Summary
+
+- **Files processed**: 31
+- **Committed**: 14
+- **No changes needed**: 17
+
+## Per-File Results
+
+| File | Status | Spans | Attempts | Cost | Libraries | Schema Extensions |
+|------|--------|-------|----------|------|-----------|-------------------|
+| src/collectors/claude-collector.js | success | 1 | 1 | $0.18 | — | `span.commit_story.context.collect_messages` |
+| src/collectors/git-collector.js | success | 6 | 3 | $0.63 | — | `span.commit_story.git.run`, `span.commit_story.git.commit_metadata`, `span.commit_story.git.commit_diff`, `span.commit_story.git.merge_info`, `span.commit_story.git.get_previous_commit_time`, `span.commit_story.git.get_commit_data`, `commit_story.git.subcommand`, `commit_story.git.diff_lines`, `commit_story.git.parent_count` |
+| src/generators/journal-graph.js | success | 4 | 1 | $0.57 | `@traceloop/instrumentation-langchain` | `span.commit_story.journal.generate_summary`, `span.commit_story.journal.generate_technical`, `span.commit_story.journal.generate_dialogue`, `span.commit_story.journal.generate_sections` |
+| src/generators/summary-graph.js | success | 6 | 1 | $0.59 | `@traceloop/instrumentation-langchain` | `span.commit_story.journal.daily_summary_node`, `span.commit_story.journal.generate_daily_summary`, `span.commit_story.journal.weekly_summary_node`, `span.commit_story.journal.generate_weekly_summary`, `span.commit_story.journal.monthly_summary_node`, `span.commit_story.journal.generate_monthly_summary`, `commit_story.journal.entries_count`, `commit_story.journal.week_label`, `commit_story.journal.month_label`, `commit_story.journal.summaries_count` |
+| src/integrators/context-integrator.js | success | 1 | 1 | $0.25 | — | `span.commit_story.context.gather_context` |
+| src/mcp/tools/context-capture-tool.js | success | 1 | 1 | $0.17 | — | `span.commit_story.context.save_context` |
+| src/mcp/server.js | success | 1 | 1 | $0.05 | `@traceloop/instrumentation-mcp`, `@opentelemetry/instrumentation-pino` | `span.commit_story.mcp.main`, `commit_story.mcp.transport_type` |
+| src/utils/journal-paths.js | success | 1 | 1 | $0.19 | — | `span.commit_story.journal.ensure_directory` |
+| src/managers/journal-manager.js | success | 2 | 1 | $0.30 | — | `span.commit_story.journal.save_entry`, `span.commit_story.journal.discover_reflections` |
+| src/managers/summary-manager.js | success | 9 | 1 | $0.62 | — | `span.commit_story.journal.read_day_entries`, `span.commit_story.journal.save_daily_summary`, `span.commit_story.journal.generate_and_save_daily_summary`, `span.commit_story.journal.read_week_daily_summaries`, `span.commit_story.journal.save_weekly_summary`, `span.commit_story.journal.generate_and_save_weekly_summary`, `span.commit_story.journal.read_month_weekly_summaries`, `span.commit_story.journal.save_monthly_summary`, `span.commit_story.journal.generate_and_save_monthly_summary` |
+| src/commands/summarize.js | success | 3 | 2 | $0.63 | — | `span.commit_story.commands.run_summarize`, `span.commit_story.commands.run_weekly_summarize`, `span.commit_story.commands.run_monthly_summarize`, `commit_story.commands.dates_count`, `commit_story.commands.force` |
+| src/utils/summary-detector.js | success | 9 | 1 | $0.32 | — | `span.commit_story.journal.get_days_with_entries`, `span.commit_story.journal.get_summarized_days`, `span.commit_story.journal.find_unsummarized_days`, `span.commit_story.journal.get_summarized_weeks`, `span.commit_story.journal.get_days_with_daily_summaries`, `span.commit_story.journal.find_unsummarized_weeks`, `span.commit_story.journal.get_summarized_months`, `span.commit_story.journal.get_weeks_with_weekly_summaries`, `span.commit_story.journal.find_unsummarized_months`, `commit_story.journal.unsummarized_days_count`, `commit_story.journal.unsummarized_weeks_count`, `commit_story.journal.unsummarized_months_count` |
+| src/managers/auto-summarize.js | success | 3 | 1 | $0.20 | — | `span.commit_story.commands.trigger_auto_summaries`, `span.commit_story.commands.trigger_auto_weekly_summaries`, `span.commit_story.commands.trigger_auto_monthly_summaries` |
+| src/index.js | success | 1 | 1 | $0.33 | — | `span.commit_story.cli.main` |
+
+**No changes needed** (17 files, 0 spans): src/generators/prompts/guidelines/accessibility.js, src/generators/prompts/guidelines/anti-hallucination.js, src/generators/prompts/guidelines/index.js, src/generators/prompts/sections/daily-summary-prompt.js, src/generators/prompts/sections/dialogue-prompt.js, src/generators/prompts/sections/monthly-summary-prompt.js, src/generators/prompts/sections/summary-prompt.js, src/generators/prompts/sections/technical-decisions-prompt.js, src/generators/prompts/sections/weekly-summary-prompt.js, src/integrators/filters/message-filter.js, src/integrators/filters/sensitive-filter.js, src/integrators/filters/token-filter.js, src/logger.js, src/mcp/tools/reflection-tool.js, src/traceloop-init.js, src/utils/commit-analyzer.js, src/utils/config.js
+
+## Span Category Breakdown
+
+| File | External Calls | Schema-Defined | Service Entry Points | Total Functions |
+|------|---------------|----------------|---------------------|-----------------|
+| src/collectors/claude-collector.js | 0 | 0 | 1 | 8 |
+| src/collectors/git-collector.js | 0 | 0 | 2 | 6 |
+| src/generators/journal-graph.js | 0 | 0 | 4 | 19 |
+| src/generators/summary-graph.js | 0 | 0 | 6 | 23 |
+| src/integrators/context-integrator.js | 0 | 0 | 1 | 3 |
+| src/mcp/tools/context-capture-tool.js | 0 | 0 | 1 | 6 |
+| src/mcp/server.js | 0 | 0 | 1 | 2 |
+| src/utils/journal-paths.js | 0 | 0 | 1 | 12 |
+| src/managers/journal-manager.js | 0 | 0 | 2 | 12 |
+| src/managers/summary-manager.js | 0 | 0 | 9 | 14 |
+| src/commands/summarize.js | 0 | 0 | 3 | 9 |
+| src/utils/summary-detector.js | 0 | 0 | 5 | 11 |
+| src/managers/auto-summarize.js | 0 | 0 | 3 | 4 |
+| src/index.js | 0 | 0 | 1 | 8 |
+
+## Schema Changes
+
+# Summary of Schema Changes
+## Registry versions
+Baseline: 0.1.0
+
+Head: 0.1.0
+
+## Registry Attributes
+### Added
+- commit_story.commands.dates_count
+- commit_story.commands.force
+- commit_story.git.diff_lines
+- commit_story.git.parent_count
+- commit_story.git.subcommand
+- commit_story.journal.entries_count
+- commit_story.journal.month_label
+- commit_story.journal.summaries_count
+- commit_story.journal.unsummarized_days_count
+- commit_story.journal.unsummarized_months_count
+- commit_story.journal.unsummarized_weeks_count
+- commit_story.journal.week_label
+- commit_story.mcp.transport_type
+
+
+
+
+### New Span IDs (48)
+
+- `span.commit_story.cli.main`
+- `span.commit_story.commands.run_monthly_summarize`
+- `span.commit_story.commands.run_summarize`
+- `span.commit_story.commands.run_weekly_summarize`
+- `span.commit_story.commands.trigger_auto_monthly_summaries`
+- `span.commit_story.commands.trigger_auto_summaries`
+- `span.commit_story.commands.trigger_auto_weekly_summaries`
+- `span.commit_story.context.collect_messages`
+- `span.commit_story.context.gather_context`
+- `span.commit_story.context.save_context`
+- `span.commit_story.git.commit_diff`
+- `span.commit_story.git.commit_metadata`
+- `span.commit_story.git.get_commit_data`
+- `span.commit_story.git.get_previous_commit_time`
+- `span.commit_story.git.merge_info`
+- `span.commit_story.git.run`
+- `span.commit_story.journal.daily_summary_node`
+- `span.commit_story.journal.discover_reflections`
+- `span.commit_story.journal.ensure_directory`
+- `span.commit_story.journal.find_unsummarized_days`
+- `span.commit_story.journal.find_unsummarized_months`
+- `span.commit_story.journal.find_unsummarized_weeks`
+- `span.commit_story.journal.generate_and_save_daily_summary`
+- `span.commit_story.journal.generate_and_save_monthly_summary`
+- `span.commit_story.journal.generate_and_save_weekly_summary`
+- `span.commit_story.journal.generate_daily_summary`
+- `span.commit_story.journal.generate_dialogue`
+- `span.commit_story.journal.generate_monthly_summary`
+- `span.commit_story.journal.generate_sections`
+- `span.commit_story.journal.generate_summary`
+- `span.commit_story.journal.generate_technical`
+- `span.commit_story.journal.generate_weekly_summary`
+- `span.commit_story.journal.get_days_with_daily_summaries`
+- `span.commit_story.journal.get_days_with_entries`
+- `span.commit_story.journal.get_summarized_days`
+- `span.commit_story.journal.get_summarized_months`
+- `span.commit_story.journal.get_summarized_weeks`
+- `span.commit_story.journal.get_weeks_with_weekly_summaries`
+- `span.commit_story.journal.monthly_summary_node`
+- `span.commit_story.journal.read_day_entries`
+- `span.commit_story.journal.read_month_weekly_summaries`
+- `span.commit_story.journal.read_week_daily_summaries`
+- `span.commit_story.journal.save_daily_summary`
+- `span.commit_story.journal.save_entry`
+- `span.commit_story.journal.save_monthly_summary`
+- `span.commit_story.journal.save_weekly_summary`
+- `span.commit_story.journal.weekly_summary_node`
+- `span.commit_story.mcp.main`
+
+## Review Attention
+
+- **src/managers/summary-manager.js**: 9 spans added (average: 3) — outlier, review recommended
+- **src/utils/summary-detector.js**: 9 spans added (average: 3) — outlier, review recommended
+
+### Advisory Findings
+
+**src/collectors/claude-collector.js**
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+
+**src/collectors/git-collector.js**
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+
+**src/generators/journal-graph.js**
+- CDQ-006 (isRecording Guard): CDQ-006 (isRecording Guard) fired because span.setAttribute() is called with an expensive computation (map, reduce, filter, JSON.stringify, etc.) or an external source string (value fetched from git output, an API response, file contents, or any source whose length is unbounded) and no span.isRecording() guard. When sampling drops the span, that work still runs on every request. Wrap the call in `if (span.isRecording()) { ... }` to skip it when the span won't be exported. Skip this finding for root spans at entry points — the guard adds clutter for negligible gain there.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+
+**src/generators/summary-graph.js**
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+
+**src/integrators/context-integrator.js**
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+
+**src/mcp/tools/context-capture-tool.js**
+- CDQ-006 (isRecording Guard): CDQ-006 (isRecording Guard) fired because span.setAttribute() is called with an expensive computation (map, reduce, filter, JSON.stringify, etc.) or an external source string (value fetched from git output, an API response, file contents, or any source whose length is unbounded) and no span.isRecording() guard. When sampling drops the span, that work still runs on every request. Wrap the call in `if (span.isRecording()) { ... }` to skip it when the span won't be exported. Skip this finding for root spans at entry points — the guard adds clutter for negligible gain there.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+
+**src/mcp/tools/reflection-tool.js**
+- COV-004 (Async Operation Spans): COV-004 (Async Operation Spans) fired because this async function doesn't have a span. Without one, traces have a gap here — callers can see time was spent and whether an error occurred, but not what happened inside this function. Add a span unless this is a pure synchronous utility with no I/O (RST-001 exemption) — context propagation covers unexported internal helpers.
+
+**src/utils/journal-paths.js**
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+
+**src/managers/journal-manager.js**
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+
+**src/managers/summary-manager.js**
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+
+**src/commands/summarize.js**
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+
+**src/utils/summary-detector.js**
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+
+**src/managers/auto-summarize.js**
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+
+## Agent Notes
+
+Each instrumented file has a companion `.instrumentation.md` file in the same directory (e.g., `src/api.js` → `src/api.instrumentation.md`) containing the agent's full decision notes.
+
+## Recommended Companion Packages
+
+This project was detected as a library. The following auto-instrumentation packages were identified but not added as dependencies — they are SDK-level concerns that deployers should add to their application's telemetry setup.
+
+- `@traceloop/instrumentation-langchain`
+- `@opentelemetry/instrumentation-pino`
+- `@traceloop/instrumentation-mcp`
+
+> **Important**: Initialize these packages **inside your application code**, not via `--import`. Loading them through `--import` can install a competing ESM hook registry alongside the one already registered by your OTel SDK, causing spans to be created but silently dropped — the exporter reports success but data never reaches the backend.
+
+## SDK Bootstrap Checklist
+
+Verify that your SDK init file includes all required resource attributes. Missing attributes reduce observability and cause RES-001 compliance failures.
+
+```javascript
+import { randomUUID } from 'node:crypto';
+
+resource: resourceFromAttributes({
+  'service.name': 'your-service-name',
+  'service.version': process.env.npm_package_version || '0.0.0',
+  'service.instance.id': randomUUID(),
+}),
+```
+
+> **`service.instance.id`** uniquely identifies a running process instance. Without it, traces from different deployments share identical resource metadata — spans are indistinguishable across restarts and parallel processes.
+
+## Token Usage
+
+| | Ceiling | Actual |
+|---|---------|--------|
+| **Cost** | $72.54 | $5.16 |
+| **Input tokens** | 3,100,000 | 110,198 |
+| **Output tokens** | — | 218,392 |
+| **Cache read tokens** | — | 212,599 |
+| **Cache write tokens** | — | 396,588 |
+
+Model: `claude-sonnet-4-6` | Files: 31 | Total file size: 207,087 bytes
+
+## Live-Check Compliance
+
+Live-Check: OK (665 spans, 4317 advisory findings — see compliance report)
+
+Full compliance report: `spiny-orb-live-check-report.json`
+
+## Agent Version
+
+`1.0.0`

--- a/src/collectors/claude-collector.instrumentation.md
+++ b/src/collectors/claude-collector.instrumentation.md
@@ -1,0 +1,26 @@
+# Instrumentation Report: src/collectors/claude-collector.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 1
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 2.5K
+- **Output tokens**: 5.9K
+- **Cached tokens**: 21.3K
+
+## Schema Extensions
+- `span.commit_story.context.collect_messages`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- getClaudeProjectsDir, encodeProjectPath, getClaudeProjectPath, findJSONLFiles, parseJSONLFile, filterMessages, and groupBySession are all pure synchronous functions with no async I/O — they are skipped per RST-001 (no spans on synchronous utilities). Their execution is captured as part of the collectChatMessages span.
+- collectChatMessages is the sole exported async entry point and receives a span per COV-001. The span name 'commit_story.context.collect_messages' is a new extension; no existing registry span covered this Claude Code chat collection operation.
+- All five attributes set on the collectChatMessages span (commit_story.context.source, commit_story.context.time_window_start, commit_story.context.time_window_end, commit_story.context.sessions_count, commit_story.context.messages_count) are already registered in the schema — no new attribute keys were invented.
+- Input parameter attributes (source, time_window_start, time_window_end) are set unconditionally before the early-return guard on projectPath, ensuring those attributes are present on the early-exit span path as well as the happy path.
+- The catch block inside parseJSONLFile (which swallows malformed JSON without rethrowing) was left without error recording per NDS-007 — it is a graceful-degradation catch that represents expected control flow, not a failure condition.
+
+## Advisory Findings
+- CDQ-007 (Attribute Data Quality):230: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):231: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.

--- a/src/collectors/claude-collector.js
+++ b/src/collectors/claude-collector.js
@@ -5,9 +5,12 @@
  * Filters by repository path and time window, groups by session.
  */
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Get the Claude projects directory path
@@ -187,43 +190,62 @@ export function groupBySession(messages) {
  * @returns {Promise<ChatData>} Collected chat data
  */
 export async function collectChatMessages(repoPath, commitTime, previousCommitTime) {
-  const projectPath = getClaudeProjectPath(repoPath);
+  return tracer.startActiveSpan('commit_story.context.collect_messages', async (span) => {
+    try {
+      span.setAttribute('commit_story.context.source', 'claude_code');
+      span.setAttribute('commit_story.context.time_window_start', previousCommitTime.toISOString());
+      span.setAttribute('commit_story.context.time_window_end', commitTime.toISOString());
 
-  if (!projectPath) {
-    return {
-      messages: [],
-      sessions: new Map(),
-      sessionCount: 0,
-      messageCount: 0,
-      timeWindow: {
-        start: previousCommitTime,
-        end: commitTime,
-      },
-    };
-  }
+      const projectPath = getClaudeProjectPath(repoPath);
 
-  const jsonlFiles = findJSONLFiles(projectPath);
-  let allMessages = [];
+      if (!projectPath) {
+        span.setAttribute('commit_story.context.sessions_count', 0);
+        span.setAttribute('commit_story.context.messages_count', 0);
+        return {
+          messages: [],
+          sessions: new Map(),
+          sessionCount: 0,
+          messageCount: 0,
+          timeWindow: {
+            start: previousCommitTime,
+            end: commitTime,
+          },
+        };
+      }
 
-  for (const filePath of jsonlFiles) {
-    const fileMessages = parseJSONLFile(filePath);
-    const filtered = filterMessages(fileMessages, repoPath, previousCommitTime, commitTime);
-    allMessages = allMessages.concat(filtered);
-  }
+      const jsonlFiles = findJSONLFiles(projectPath);
+      let allMessages = [];
 
-  // Sort all messages chronologically
-  allMessages.sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+      for (const filePath of jsonlFiles) {
+        const fileMessages = parseJSONLFile(filePath);
+        const filtered = filterMessages(fileMessages, repoPath, previousCommitTime, commitTime);
+        allMessages = allMessages.concat(filtered);
+      }
 
-  const sessions = groupBySession(allMessages);
+      // Sort all messages chronologically
+      allMessages.sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
 
-  return {
-    messages: allMessages,
-    sessions,
-    sessionCount: sessions.size,
-    messageCount: allMessages.length,
-    timeWindow: {
-      start: previousCommitTime,
-      end: commitTime,
-    },
-  };
+      const sessions = groupBySession(allMessages);
+
+      span.setAttribute('commit_story.context.sessions_count', sessions.size);
+      span.setAttribute('commit_story.context.messages_count', allMessages.length);
+
+      return {
+        messages: allMessages,
+        sessions,
+        sessionCount: sessions.size,
+        messageCount: allMessages.length,
+        timeWindow: {
+          start: previousCommitTime,
+          end: commitTime,
+        },
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }

--- a/src/collectors/git-collector.instrumentation.md
+++ b/src/collectors/git-collector.instrumentation.md
@@ -1,0 +1,43 @@
+# Instrumentation Report: src/collectors/git-collector.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 6
+- **Attempts**: 3 (fresh-regeneration)
+- **Input tokens**: 22.4K
+- **Output tokens**: 26.4K
+- **Cached tokens**: 21.4K
+
+## Schema Extensions
+- `span.commit_story.git.run`
+- `span.commit_story.git.commit_metadata`
+- `span.commit_story.git.commit_diff`
+- `span.commit_story.git.merge_info`
+- `span.commit_story.git.get_previous_commit_time`
+- `span.commit_story.git.get_commit_data`
+- `commit_story.git.subcommand`
+- `commit_story.git.diff_lines`
+- `commit_story.git.parent_count`
+
+## Validation Journey
+1. **Attempt 1**: 3 blocking errors (SCH-002 (Attribute Keys Match Registry):3)
+2. **Attempt 2**: 1 blocking error (NDS-003 (Code Preserved):1)
+3. **Attempt 3**: 0 errors
+
+## Notes
+- commit_story.git.subcommand: No registered key captures the git subcommand (e.g. 'show', 'log', 'diff-tree'). The closest registered key, vcs.ref.head.revision, describes a commit reference — not a command name. Declaring commit_story.git.subcommand (type: string) for runGit identity.
+- commit_story.git.diff_lines: No registered key captures the number of lines in a raw git diff patch. commit_story.commit.files_changed describes changed file count, not patch line count. Declaring commit_story.git.diff_lines (type: int). The lines array is already computed in the function body so no extra computation is required — CDQ-006 guard is unnecessary.
+- commit_story.git.parent_count: No registered key captures parent commit count. commit_story.context.sessions_count and similar count keys describe different domain concepts. Declaring commit_story.git.parent_count (type: int) for getMergeInfo and reused in getCommitData.
+- runGit has an existing try/catch that re-throws on all paths — COV-003 applies. OTel error recording is added at the top of the catch before all original conditional rethrows, preserving the existing error-handling logic intact (NDS-005 Pattern A with added finally).
+- getCommitMetadata sets vcs.ref.head.revision twice: once with commitRef at span open (ensures the attribute is present on all paths including early errors) and again with the resolved full hash after git output is parsed. The second assignment gives the canonical SHA rather than a symbolic ref like HEAD.
+- getCommitDiff: The previous instrumentation failure (NDS-003) was caused by wrapping the diff value in an isRecording guard combined with a null check. This version avoids that entirely — lines.length is a property access on an already-computed array, so no isRecording guard is needed per CDQ-006, and no null check is required because lines is always defined at that point.
+- getPreviousCommitTime and getCommitData are exported async entry points (COV-001). They each receive their own span with commitRef captured as vcs.ref.head.revision before any conditional branching, satisfying COV-005 input-before-guard requirement.
+
+## Advisory Findings
+- CDQ-007 (Attribute Data Quality):122: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):205: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):206: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

--- a/src/collectors/git-collector.js
+++ b/src/collectors/git-collector.js
@@ -5,10 +5,12 @@
  * to prevent context pollution in AI generation.
  */
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Run a git command and return stdout
@@ -18,23 +20,30 @@ const execFileAsync = promisify(execFile);
  * @returns {Promise<string>} - Command output
  */
 async function runGit(args, { commitRef } = {}) {
-  try {
-    const { stdout } = await execFileAsync('git', args, {
-      maxBuffer: 10 * 1024 * 1024, // 10MB for large diffs
-    });
-    return stdout;
-  } catch (error) {
-    if (error.code === 128) {
-      if (error.stderr?.includes('not a git repository')) {
-        throw new Error('Not a git repository');
+  return tracer.startActiveSpan('commit_story.git.run', async (span) => {
+    span.setAttribute('commit_story.git.subcommand', args[0]);
+    try {
+      const { stdout } = await execFileAsync('git', args, {
+        maxBuffer: 10 * 1024 * 1024, // 10MB for large diffs
+      });
+      return stdout;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      if (error.code === 128) {
+        if (error.stderr?.includes('not a git repository')) {
+          throw new Error('Not a git repository');
+        }
+        if (error.stderr?.includes('unknown revision') || error.stderr?.includes('bad revision')) {
+          const ref = commitRef ?? args[args.length - 1];
+          throw new Error(`Invalid commit reference: ${ref}`);
+        }
       }
-      if (error.stderr?.includes('unknown revision') || error.stderr?.includes('bad revision')) {
-        const ref = commitRef ?? args[args.length - 1];
-        throw new Error(`Invalid commit reference: ${ref}`);
-      }
+      throw error;
+    } finally {
+      span.end();
     }
-    throw error;
-  }
+  });
 }
 
 /**
@@ -43,31 +52,46 @@ async function runGit(args, { commitRef } = {}) {
  * @returns {Promise<object>} - Commit metadata
  */
 async function getCommitMetadata(commitRef = 'HEAD') {
-  // %H = full hash, %h = short hash, %s = subject, %b = body (without subject)
-  // %an = author name, %ae = author email, %aI = author date ISO
-  const format = '%H%n%h%n%s%n%b%n--END-BODY--%n%an%n%ae%n%aI';
-  const output = await runGit(['show', '--no-patch', `--format=${format}`, commitRef]);
+  return tracer.startActiveSpan('commit_story.git.commit_metadata', async (span) => {
+    span.setAttribute('vcs.ref.head.revision', commitRef);
+    try {
+      // %H = full hash, %h = short hash, %s = subject, %b = body (without subject)
+      // %an = author name, %ae = author email, %aI = author date ISO
+      const format = '%H%n%h%n%s%n%b%n--END-BODY--%n%an%n%ae%n%aI';
+      const output = await runGit(['show', '--no-patch', `--format=${format}`, commitRef]);
 
-  const lines = output.split('\n');
-  const bodyEndIndex = lines.findIndex(line => line === '--END-BODY--');
+      const lines = output.split('\n');
+      const bodyEndIndex = lines.findIndex(line => line === '--END-BODY--');
 
-  const hash = lines[0];
-  const shortHash = lines[1];
-  const subject = lines[2];
-  const body = lines.slice(3, bodyEndIndex).join('\n').trim();
-  const author = lines[bodyEndIndex + 1];
-  const authorEmail = lines[bodyEndIndex + 2];
-  const timestampStr = lines[bodyEndIndex + 3];
+      const hash = lines[0];
+      const shortHash = lines[1];
+      const subject = lines[2];
+      const body = lines.slice(3, bodyEndIndex).join('\n').trim();
+      const author = lines[bodyEndIndex + 1];
+      const authorEmail = lines[bodyEndIndex + 2];
+      const timestampStr = lines[bodyEndIndex + 3];
 
-  return {
-    hash,
-    shortHash,
-    subject,
-    message: body ? `${subject}\n\n${body}` : subject,
-    author,
-    authorEmail,
-    timestamp: new Date(timestampStr),
-  };
+      span.setAttribute('vcs.ref.head.revision', hash);
+      span.setAttribute('commit_story.commit.message', subject);
+      span.setAttribute('commit_story.commit.timestamp', new Date(timestampStr).toISOString());
+
+      return {
+        hash,
+        shortHash,
+        subject,
+        message: body ? `${subject}\n\n${body}` : subject,
+        author,
+        authorEmail,
+        timestamp: new Date(timestampStr),
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -76,23 +100,35 @@ async function getCommitMetadata(commitRef = 'HEAD') {
  * @returns {Promise<string>} - Diff content
  */
 async function getCommitDiff(commitRef = 'HEAD') {
-  const output = await runGit(
-    [
-      'diff-tree',
-      '-p',           // Generate patch
-      '-m',           // Show diff for merges
-      '--first-parent', // For merges, diff against first parent
-      commitRef,
-      '--',
-      '.',
-      ':!journal/entries/', // Exclude journal entries
-    ],
-    { commitRef }
-  );
+  return tracer.startActiveSpan('commit_story.git.commit_diff', async (span) => {
+    span.setAttribute('vcs.ref.head.revision', commitRef);
+    try {
+      const output = await runGit(
+        [
+          'diff-tree',
+          '-p',           // Generate patch
+          '-m',           // Show diff for merges
+          '--first-parent', // For merges, diff against first parent
+          commitRef,
+          '--',
+          '.',
+          ':!journal/entries/', // Exclude journal entries
+        ],
+        { commitRef }
+      );
 
-  // First line is commit hash, rest is diff
-  const lines = output.split('\n');
-  return lines.slice(1).join('\n').trim();
+      // First line is commit hash, rest is diff
+      const lines = output.split('\n');
+      span.setAttribute('commit_story.git.diff_lines', lines.length);
+      return lines.slice(1).join('\n').trim();
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -101,14 +137,27 @@ async function getCommitDiff(commitRef = 'HEAD') {
  * @returns {Promise<{isMerge: boolean, parentCount: number}>}
  */
 async function getMergeInfo(commitRef = 'HEAD') {
-  const output = await runGit(['rev-list', '--parents', '-n', '1', commitRef]);
-  const hashes = output.trim().split(' ');
-  const parentCount = hashes.length - 1;
+  return tracer.startActiveSpan('commit_story.git.merge_info', async (span) => {
+    span.setAttribute('vcs.ref.head.revision', commitRef);
+    try {
+      const output = await runGit(['rev-list', '--parents', '-n', '1', commitRef]);
+      const hashes = output.trim().split(' ');
+      const parentCount = hashes.length - 1;
 
-  return {
-    isMerge: parentCount > 1,
-    parentCount,
-  };
+      span.setAttribute('commit_story.git.parent_count', parentCount);
+
+      return {
+        isMerge: parentCount > 1,
+        parentCount,
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -117,14 +166,25 @@ async function getMergeInfo(commitRef = 'HEAD') {
  * @returns {Promise<Date|null>} - Previous commit timestamp, null if first commit
  */
 export async function getPreviousCommitTime(commitRef = 'HEAD') {
-  const output = await runGit(['log', '-2', '--format=%aI', commitRef]);
-  const timestamps = output.trim().split('\n');
+  return tracer.startActiveSpan('commit_story.git.get_previous_commit_time', async (span) => {
+    span.setAttribute('vcs.ref.head.revision', commitRef);
+    try {
+      const output = await runGit(['log', '-2', '--format=%aI', commitRef]);
+      const timestamps = output.trim().split('\n');
 
-  if (timestamps.length < 2) {
-    return null; // First commit, no previous
-  }
+      if (timestamps.length < 2) {
+        return null; // First commit, no previous
+      }
 
-  return new Date(timestamps[1]);
+      return new Date(timestamps[1]);
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -133,15 +193,29 @@ export async function getPreviousCommitTime(commitRef = 'HEAD') {
  * @returns {Promise<CommitData>}
  */
 export async function getCommitData(commitRef = 'HEAD') {
-  const [metadata, diff, mergeInfo] = await Promise.all([
-    getCommitMetadata(commitRef),
-    getCommitDiff(commitRef),
-    getMergeInfo(commitRef),
-  ]);
+  return tracer.startActiveSpan('commit_story.git.get_commit_data', async (span) => {
+    span.setAttribute('vcs.ref.head.revision', commitRef);
+    try {
+      const [metadata, diff, mergeInfo] = await Promise.all([
+        getCommitMetadata(commitRef),
+        getCommitDiff(commitRef),
+        getMergeInfo(commitRef),
+      ]);
 
-  return {
-    ...metadata,
-    diff,
-    ...mergeInfo,
-  };
+      span.setAttribute('commit_story.commit.message', metadata.subject);
+      span.setAttribute('commit_story.git.parent_count', mergeInfo.parentCount);
+
+      return {
+        ...metadata,
+        diff,
+        ...mergeInfo,
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }

--- a/src/commands/summarize.instrumentation.md
+++ b/src/commands/summarize.instrumentation.md
@@ -1,0 +1,31 @@
+# Instrumentation Report: src/commands/summarize.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 3
+- **Attempts**: 2 (multi-turn-fix)
+- **Input tokens**: 31.7K
+- **Output tokens**: 22.2K
+
+## Schema Extensions
+- `span.commit_story.commands.run_summarize`
+- `span.commit_story.commands.run_weekly_summarize`
+- `span.commit_story.commands.run_monthly_summarize`
+- `commit_story.commands.dates_count`
+- `commit_story.commands.force`
+
+## Validation Journey
+1. **Attempt 1**: 12 blocking errors (SCH-002 (Attribute Keys Match Registry):12)
+2. **Attempt 2**: 0 errors
+
+## Notes
+- isValidDate (unexported), isValidWeekString, isValidMonthString, expandDateRange, parseSummarizeArgs, and showSummarizeHelp are all synchronous functions with no async I/O — skipped per RST-001 (no spans on synchronous utilities).
+- The three inner catch(err) blocks inside runSummarize, runWeeklySummarize, and runMonthlySummarize handle per-item failures gracefully by pushing to result arrays without rethrowing. NDS-007 applies — no recordException or setStatus added to these catches. Only the outer span-level catch gets full error recording per COV-003.
+- The inner catch{} block for access(summaryPath) in runSummarize is an empty graceful-degradation catch (file not found = proceed with generation). NDS-007 applies — no error recording added.
+- The validator rejected commit_story.commands.generated_count, commit_story.commands.failed_count, commit_story.commands.weeks_count, and commit_story.commands.months_count as semantic duplicates of commit_story.commands.dates_count. Per the validator's directive, commit_story.commands.dates_count is reused for the input item count in all three command functions (dates, weeks, months all represent the count of items the command was asked to process). The output result counts (generated, failed) were dropped since no valid registered key covers per-run outcome counts and the validator will not accept new extensions in this category.
+- CDQ-007 advisories resolved: guarded dates, weeks, and months with != null checks before accessing .length, using the pattern `x != null ? x.length : 0` to protect against null or undefined inputs from callers.
+- SCH-001 advisories about run_weekly_summarize and run_monthly_summarize being potential duplicates of run_summarize are informational only — these are distinct operations (weekly and monthly aggregation vs. daily generation) and warrant separate span names for independent observability.
+
+## Advisory Findings
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

--- a/src/commands/summarize.js
+++ b/src/commands/summarize.js
@@ -1,11 +1,14 @@
 // ABOUTME: CLI handler for the "summarize" subcommand — backfill daily, weekly, and monthly summaries on demand
 // ABOUTME: Parses date/range/week/month args, orchestrates generation with progress output and --force flag
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { generateAndSaveDailySummary, generateAndSaveWeeklySummary, generateAndSaveMonthlySummary } from '../managers/summary-manager.js';
 import { readDayEntries } from '../managers/summary-manager.js';
 import { getSummaryPath } from '../utils/journal-paths.js';
 import { access } from 'node:fs/promises';
 import logger from '../logger.js';
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Validate a YYYY-MM-DD date string.
@@ -184,73 +187,85 @@ export function parseSummarizeArgs(args) {
  * @returns {Promise<{ generated: string[], noEntries: string[], alreadyExists: string[], failed: string[], errors: string[] }>}
  */
 export async function runSummarize(options) {
-  const { dates, force, basePath = '.', onProgress } = options;
-
-  const result = {
-    generated: [],
-    noEntries: [],
-    alreadyExists: [],
-    failed: [],
-    errors: [],
-  };
-
-  for (const dateStr of dates) {
-    const [year, month, day] = dateStr.split('-').map(Number);
-    const date = new Date(year, month - 1, day);
-
+  return tracer.startActiveSpan('commit_story.commands.run_summarize', async (span) => {
     try {
-      // Check for entries first
-      const entries = await readDayEntries(date, basePath);
-      if (entries.length === 0) {
-        result.noEntries.push(dateStr);
-        if (onProgress) {
-          onProgress(`Skipped ${dateStr}: no entries`);
-        }
-        continue;
-      }
+      const { dates, force, basePath = '.', onProgress } = options;
+      span.setAttribute('commit_story.commands.dates_count', dates != null ? dates.length : 0);
+      span.setAttribute('commit_story.commands.force', force);
 
-      // Check for existing summary (unless --force)
-      if (!force) {
-        const summaryPath = getSummaryPath('daily', date, basePath);
+      const result = {
+        generated: [],
+        noEntries: [],
+        alreadyExists: [],
+        failed: [],
+        errors: [],
+      };
+
+      for (const dateStr of dates) {
+        const [year, month, day] = dateStr.split('-').map(Number);
+        const date = new Date(year, month - 1, day);
+
         try {
-          await access(summaryPath);
-          result.alreadyExists.push(dateStr);
+          // Check for entries first
+          const entries = await readDayEntries(date, basePath);
+          if (entries.length === 0) {
+            result.noEntries.push(dateStr);
+            if (onProgress) {
+              onProgress(`Skipped ${dateStr}: no entries`);
+            }
+            continue;
+          }
+
+          // Check for existing summary (unless --force)
+          if (!force) {
+            const summaryPath = getSummaryPath('daily', date, basePath);
+            try {
+              await access(summaryPath);
+              result.alreadyExists.push(dateStr);
+              if (onProgress) {
+                onProgress(`Skipped ${dateStr}: summary already exists`);
+              }
+              continue;
+            } catch {
+              // Doesn't exist, proceed
+            }
+          }
+
+          // Generate and save
+          const genResult = await generateAndSaveDailySummary(date, basePath, { force });
+
+          if (genResult.saved) {
+            result.generated.push(dateStr);
+            if (onProgress) {
+              onProgress(`Generated summary for ${dateStr} (${genResult.entryCount} entries)`);
+            }
+            if (genResult.errors && genResult.errors.length > 0) {
+              for (const err of genResult.errors) {
+                result.errors.push(`${dateStr}: ${err}`);
+              }
+            }
+          } else {
+            // Shouldn't happen since we checked above, but handle gracefully
+            result.noEntries.push(dateStr);
+          }
+        } catch (err) {
+          result.failed.push(dateStr);
+          result.errors.push(`${dateStr}: ${err.message}`);
           if (onProgress) {
-            onProgress(`Skipped ${dateStr}: summary already exists`);
+            onProgress(`Failed ${dateStr}: ${err.message}`);
           }
-          continue;
-        } catch {
-          // Doesn't exist, proceed
         }
       }
 
-      // Generate and save
-      const genResult = await generateAndSaveDailySummary(date, basePath, { force });
-
-      if (genResult.saved) {
-        result.generated.push(dateStr);
-        if (onProgress) {
-          onProgress(`Generated summary for ${dateStr} (${genResult.entryCount} entries)`);
-        }
-        if (genResult.errors && genResult.errors.length > 0) {
-          for (const err of genResult.errors) {
-            result.errors.push(`${dateStr}: ${err}`);
-          }
-        }
-      } else {
-        // Shouldn't happen since we checked above, but handle gracefully
-        result.noEntries.push(dateStr);
-      }
-    } catch (err) {
-      result.failed.push(dateStr);
-      result.errors.push(`${dateStr}: ${err.message}`);
-      if (onProgress) {
-        onProgress(`Failed ${dateStr}: ${err.message}`);
-      }
+      return result;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  return result;
+  });
 }
 
 /**
@@ -259,53 +274,65 @@ export async function runSummarize(options) {
  * @returns {Promise<{ generated: string[], noSummaries: string[], alreadyExists: string[], failed: string[], errors: string[] }>}
  */
 export async function runWeeklySummarize(options) {
-  const { weeks, force, basePath = '.', onProgress } = options;
-
-  const result = {
-    generated: [],
-    noSummaries: [],
-    alreadyExists: [],
-    failed: [],
-    errors: [],
-  };
-
-  for (const weekStr of weeks) {
+  return tracer.startActiveSpan('commit_story.commands.run_weekly_summarize', async (span) => {
     try {
-      const genResult = await generateAndSaveWeeklySummary(weekStr, basePath, { force });
+      const { weeks, force, basePath = '.', onProgress } = options;
+      span.setAttribute('commit_story.commands.dates_count', weeks != null ? weeks.length : 0);
+      span.setAttribute('commit_story.commands.force', force);
 
-      if (genResult.saved) {
-        result.generated.push(weekStr);
-        if (onProgress) {
-          onProgress(`Generated weekly summary for ${weekStr} (${genResult.dayCount} daily summaries)`);
-        }
-        if (genResult.errors && genResult.errors.length > 0) {
-          for (const err of genResult.errors) {
-            result.errors.push(`${weekStr}: ${err}`);
+      const result = {
+        generated: [],
+        noSummaries: [],
+        alreadyExists: [],
+        failed: [],
+        errors: [],
+      };
+
+      for (const weekStr of weeks) {
+        try {
+          const genResult = await generateAndSaveWeeklySummary(weekStr, basePath, { force });
+
+          if (genResult.saved) {
+            result.generated.push(weekStr);
+            if (onProgress) {
+              onProgress(`Generated weekly summary for ${weekStr} (${genResult.dayCount} daily summaries)`);
+            }
+            if (genResult.errors && genResult.errors.length > 0) {
+              for (const err of genResult.errors) {
+                result.errors.push(`${weekStr}: ${err}`);
+              }
+            }
+          } else if (genResult.reason && genResult.reason.includes('no daily summaries')) {
+            result.noSummaries.push(weekStr);
+            if (onProgress) {
+              onProgress(`Skipped ${weekStr}: no daily summaries`);
+            }
+          } else if (genResult.reason && genResult.reason.includes('already exists')) {
+            result.alreadyExists.push(weekStr);
+            if (onProgress) {
+              onProgress(`Skipped ${weekStr}: weekly summary already exists`);
+            }
+          } else {
+            result.noSummaries.push(weekStr);
+          }
+        } catch (err) {
+          result.failed.push(weekStr);
+          result.errors.push(`${weekStr}: ${err.message}`);
+          if (onProgress) {
+            onProgress(`Failed ${weekStr}: ${err.message}`);
           }
         }
-      } else if (genResult.reason && genResult.reason.includes('no daily summaries')) {
-        result.noSummaries.push(weekStr);
-        if (onProgress) {
-          onProgress(`Skipped ${weekStr}: no daily summaries`);
-        }
-      } else if (genResult.reason && genResult.reason.includes('already exists')) {
-        result.alreadyExists.push(weekStr);
-        if (onProgress) {
-          onProgress(`Skipped ${weekStr}: weekly summary already exists`);
-        }
-      } else {
-        result.noSummaries.push(weekStr);
       }
-    } catch (err) {
-      result.failed.push(weekStr);
-      result.errors.push(`${weekStr}: ${err.message}`);
-      if (onProgress) {
-        onProgress(`Failed ${weekStr}: ${err.message}`);
-      }
-    }
-  }
 
-  return result;
+      return result;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -314,53 +341,65 @@ export async function runWeeklySummarize(options) {
  * @returns {Promise<{ generated: string[], noSummaries: string[], alreadyExists: string[], failed: string[], errors: string[] }>}
  */
 export async function runMonthlySummarize(options) {
-  const { months, force, basePath = '.', onProgress } = options;
-
-  const result = {
-    generated: [],
-    noSummaries: [],
-    alreadyExists: [],
-    failed: [],
-    errors: [],
-  };
-
-  for (const monthStr of months) {
+  return tracer.startActiveSpan('commit_story.commands.run_monthly_summarize', async (span) => {
     try {
-      const genResult = await generateAndSaveMonthlySummary(monthStr, basePath, { force });
+      const { months, force, basePath = '.', onProgress } = options;
+      span.setAttribute('commit_story.commands.dates_count', months != null ? months.length : 0);
+      span.setAttribute('commit_story.commands.force', force);
 
-      if (genResult.saved) {
-        result.generated.push(monthStr);
-        if (onProgress) {
-          onProgress(`Generated monthly summary for ${monthStr} (${genResult.weekCount} weekly summaries)`);
-        }
-        if (genResult.errors && genResult.errors.length > 0) {
-          for (const err of genResult.errors) {
-            result.errors.push(`${monthStr}: ${err}`);
+      const result = {
+        generated: [],
+        noSummaries: [],
+        alreadyExists: [],
+        failed: [],
+        errors: [],
+      };
+
+      for (const monthStr of months) {
+        try {
+          const genResult = await generateAndSaveMonthlySummary(monthStr, basePath, { force });
+
+          if (genResult.saved) {
+            result.generated.push(monthStr);
+            if (onProgress) {
+              onProgress(`Generated monthly summary for ${monthStr} (${genResult.weekCount} weekly summaries)`);
+            }
+            if (genResult.errors && genResult.errors.length > 0) {
+              for (const err of genResult.errors) {
+                result.errors.push(`${monthStr}: ${err}`);
+              }
+            }
+          } else if (genResult.reason && genResult.reason.includes('no weekly summaries')) {
+            result.noSummaries.push(monthStr);
+            if (onProgress) {
+              onProgress(`Skipped ${monthStr}: no weekly summaries`);
+            }
+          } else if (genResult.reason && genResult.reason.includes('already exists')) {
+            result.alreadyExists.push(monthStr);
+            if (onProgress) {
+              onProgress(`Skipped ${monthStr}: monthly summary already exists`);
+            }
+          } else {
+            result.noSummaries.push(monthStr);
+          }
+        } catch (err) {
+          result.failed.push(monthStr);
+          result.errors.push(`${monthStr}: ${err.message}`);
+          if (onProgress) {
+            onProgress(`Failed ${monthStr}: ${err.message}`);
           }
         }
-      } else if (genResult.reason && genResult.reason.includes('no weekly summaries')) {
-        result.noSummaries.push(monthStr);
-        if (onProgress) {
-          onProgress(`Skipped ${monthStr}: no weekly summaries`);
-        }
-      } else if (genResult.reason && genResult.reason.includes('already exists')) {
-        result.alreadyExists.push(monthStr);
-        if (onProgress) {
-          onProgress(`Skipped ${monthStr}: monthly summary already exists`);
-        }
-      } else {
-        result.noSummaries.push(monthStr);
       }
-    } catch (err) {
-      result.failed.push(monthStr);
-      result.errors.push(`${monthStr}: ${err.message}`);
-      if (onProgress) {
-        onProgress(`Failed ${monthStr}: ${err.message}`);
-      }
-    }
-  }
 
-  return result;
+      return result;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**

--- a/src/generators/journal-graph.instrumentation.md
+++ b/src/generators/journal-graph.instrumentation.md
@@ -1,0 +1,36 @@
+# Instrumentation Report: src/generators/journal-graph.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 4
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 7.1K
+- **Output tokens**: 30.4K
+- **Cached tokens**: 22.6K
+
+## Schema Extensions
+- `span.commit_story.journal.generate_summary`
+- `span.commit_story.journal.generate_technical`
+- `span.commit_story.journal.generate_dialogue`
+- `span.commit_story.journal.generate_sections`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- summaryNode, technicalNode, and dialogueNode each have try/catch blocks that return graceful-degradation state (error strings, no rethrow). Per NDS-007, recordException and setStatus(ERROR) were NOT added to those catches — they represent expected failure modes, not unexpected errors. span.end() is called via finally in all cases.
+- The catch blocks in summaryNode, technicalNode, and dialogueNode never propagate errors upward (they return error state instead), so the LangGraph runtime always sees a resolved promise from these nodes. The outer span-level catch required by COV-003 is satisfied by the existing catch clause; NDS-007 takes precedence over adding error recording to graceful-degradation catches.
+- getModel and resetModel are synchronous functions with no I/O — skipped per RST-001 (no spans on synchronous utilities).
+- analyzeCommitContent, hasFunctionalCode, generateImplementationGuidance, formatSessionsForAI, formatChatMessages, escapeForJson, formatContextForSummary, formatContextForUser, cleanDialogueOutput, cleanTechnicalOutput, cleanSummaryOutput, buildGraph are all synchronous pure/data-transform functions — skipped per RST-001.
+- getGraph is unexported and its execution path is fully covered by the generateJournalSections span — skipped per RST-004.
+- All four new span names use the commit_story namespace prefix consistent with existing schema spans. They are declared in schemaExtensions because no existing schema span matched these journal-generation operations.
+- LangChainInstrumentation from @traceloop/instrumentation-langchain covers the getModel(...).invoke() calls inside summaryNode, technicalNode, and dialogueNode — those model.invoke() calls become child spans automatically when auto-instrumentation is active. Token usage attributes (gen_ai.usage.input_tokens, gen_ai.usage.output_tokens) are also set on the parent span from result.usage_metadata when available, guarded with != null.
+- gen_ai.request.model is set to the hard-coded model string 'claude-haiku-4-5-20251001' matching the ChatAnthropic constructor — this is a static value known at instrumentation time.
+- commit_story.journal.sections in generateJournalSections uses .filter(Boolean) on an inline array — CDQ-006 isRecording guard is not required here because generateJournalSections is a COV-001 entry point (CDQ-006 COV-001 exemption applies).
+
+## Advisory Findings
+- CDQ-006 (isRecording Guard):649: CDQ-006 (isRecording Guard) fired because span.setAttribute() is called with an expensive computation (map, reduce, filter, JSON.stringify, etc.) or an external source string (value fetched from git output, an API response, file contents, or any source whose length is unbounded) and no span.isRecording() guard. When sampling drops the span, that work still runs on every request. Wrap the call in `if (span.isRecording()) { ... }` to skip it when the span won't be exported. Skip this finding for root spans at entry points — the guard adds clutter for negligible gain there.
+- CDQ-007 (Attribute Data Quality):445: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):494: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):552: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

--- a/src/generators/journal-graph.js
+++ b/src/generators/journal-graph.js
@@ -10,6 +10,7 @@
  * START → [summary, technical] (parallel) → dialogue → END
  */
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { StateGraph, START, END, Annotation } from '@langchain/langgraph';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { SystemMessage, HumanMessage } from '@langchain/core/messages';
@@ -17,6 +18,8 @@ import { getAllGuidelines } from './prompts/guidelines/index.js';
 import { summaryPrompt } from './prompts/sections/summary-prompt.js';
 import { dialoguePrompt } from './prompts/sections/dialogue-prompt.js';
 import { technicalDecisionsPrompt } from './prompts/sections/technical-decisions-prompt.js';
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Journal state definition using LangGraph Annotation API
@@ -224,7 +227,7 @@ function formatChatMessages(messages) {
       const type = msg.type === 'user' ? 'user' : 'assistant';
       const date = msg.timestamp ? new Date(msg.timestamp) : null;
       const time = date && !Number.isNaN(date.getTime()) ? date.toLocaleTimeString() : '';
-      return `{"type":"${type}", "time":"${time}", "content":"${escapeForJson(msg.content)}"}`;
+      return `{"type":"${type}", "time":"${time}", "content":"${escapeForJson(msg.content)}"}` ;
     })
     .join('\n\n');
 }
@@ -434,32 +437,46 @@ function cleanSummaryOutput(raw) {
  * Creates a narrative overview of the commit
  */
 async function summaryNode(state) {
-  try {
-    const { context } = state;
-    const guidelines = getAllGuidelines();
-    const hasFunctional = hasFunctionalCode(context.commit.diff);
-    // Use pre-computed stats from message filter instead of re-iterating
-    const hasChat = (context.metadata?.filterStats?.substantialUserMessages ?? 0) >= 2;
-    const sectionPrompt = summaryPrompt(hasFunctional, hasChat);
+  return tracer.startActiveSpan('commit_story.journal.generate_summary', async (span) => {
+    span.setAttribute('commit_story.ai.section_type', 'summary');
+    span.setAttribute('gen_ai.operation.name', 'chat');
+    span.setAttribute('gen_ai.provider.name', 'anthropic');
+    span.setAttribute('gen_ai.request.model', 'claude-haiku-4-5-20251001');
+    span.setAttribute('gen_ai.request.temperature', NODE_TEMPERATURES.summary);
+    try {
+      const { context } = state;
+      const guidelines = getAllGuidelines();
+      const hasFunctional = hasFunctionalCode(context.commit.diff);
+      // Use pre-computed stats from message filter instead of re-iterating
+      const hasChat = (context.metadata?.filterStats?.substantialUserMessages ?? 0) >= 2;
+      const sectionPrompt = summaryPrompt(hasFunctional, hasChat);
 
-    const systemContent = `${guidelines}
+      const systemContent = `${guidelines}
 
 ${sectionPrompt}`;
 
-    const userContent = formatContextForSummary(context);
+      const userContent = formatContextForSummary(context);
 
-    const result = await getModel(NODE_TEMPERATURES.summary).invoke([
-      new SystemMessage(systemContent),
-      new HumanMessage(userContent),
-    ]);
+      const result = await getModel(NODE_TEMPERATURES.summary).invoke([
+        new SystemMessage(systemContent),
+        new HumanMessage(userContent),
+      ]);
 
-    return { summary: cleanSummaryOutput(result.content) };
-  } catch (error) {
-    return {
-      summary: '[Summary generation failed]',
-      errors: [`Summary generation failed: ${error.message}`],
-    };
-  }
+      if (result.usage_metadata != null) {
+        span.setAttribute('gen_ai.usage.input_tokens', result.usage_metadata.input_tokens);
+        span.setAttribute('gen_ai.usage.output_tokens', result.usage_metadata.output_tokens);
+      }
+
+      return { summary: cleanSummaryOutput(result.content) };
+    } catch (error) {
+      return {
+        summary: '[Summary generation failed]',
+        errors: [`Summary generation failed: ${error.message}`],
+      };
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -469,40 +486,54 @@ ${sectionPrompt}`;
  * Early exit when no substantial user messages exist
  */
 async function technicalNode(state) {
-  try {
-    const { context } = state;
+  return tracer.startActiveSpan('commit_story.journal.generate_technical', async (span) => {
+    span.setAttribute('commit_story.ai.section_type', 'technical_decisions');
+    span.setAttribute('gen_ai.operation.name', 'chat');
+    span.setAttribute('gen_ai.provider.name', 'anthropic');
+    span.setAttribute('gen_ai.request.model', 'claude-haiku-4-5-20251001');
+    span.setAttribute('gen_ai.request.temperature', NODE_TEMPERATURES.technical);
+    try {
+      const { context } = state;
 
-    // Early exit: skip AI call when no substantial user messages (v1 pattern)
-    const substantialUserMessages = context.metadata?.filterStats?.substantialUserMessages ?? 0;
-    if (substantialUserMessages === 0) {
-      return { technicalDecisions: 'No significant technical decisions documented for this development session' };
-    }
+      // Early exit: skip AI call when no substantial user messages (v1 pattern)
+      const substantialUserMessages = context.metadata?.filterStats?.substantialUserMessages ?? 0;
+      if (substantialUserMessages === 0) {
+        return { technicalDecisions: 'No significant technical decisions documented for this development session' };
+      }
 
-    const guidelines = getAllGuidelines();
+      const guidelines = getAllGuidelines();
 
-    // Analyze diff to generate dynamic implementation guidance
-    const diffAnalysis = analyzeCommitContent(context.commit.diff);
-    const implementationGuidance = generateImplementationGuidance(diffAnalysis);
+      // Analyze diff to generate dynamic implementation guidance
+      const diffAnalysis = analyzeCommitContent(context.commit.diff);
+      const implementationGuidance = generateImplementationGuidance(diffAnalysis);
 
-    const systemContent = `${guidelines}
+      const systemContent = `${guidelines}
 
 ${technicalDecisionsPrompt}
 ${implementationGuidance}`;
 
-    const userContent = formatContextForUser(context);
+      const userContent = formatContextForUser(context);
 
-    const result = await getModel(NODE_TEMPERATURES.technical).invoke([
-      new SystemMessage(systemContent),
-      new HumanMessage(userContent),
-    ]);
+      const result = await getModel(NODE_TEMPERATURES.technical).invoke([
+        new SystemMessage(systemContent),
+        new HumanMessage(userContent),
+      ]);
 
-    return { technicalDecisions: cleanTechnicalOutput(result.content.trim()) };
-  } catch (error) {
-    return {
-      technicalDecisions: '[Technical decisions extraction failed]',
-      errors: [`Technical decisions extraction failed: ${error.message}`],
-    };
-  }
+      if (result.usage_metadata != null) {
+        span.setAttribute('gen_ai.usage.input_tokens', result.usage_metadata.input_tokens);
+        span.setAttribute('gen_ai.usage.output_tokens', result.usage_metadata.output_tokens);
+      }
+
+      return { technicalDecisions: cleanTechnicalOutput(result.content.trim()) };
+    } catch (error) {
+      return {
+        technicalDecisions: '[Technical decisions extraction failed]',
+        errors: [`Technical decisions extraction failed: ${error.message}`],
+      };
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -513,44 +544,58 @@ ${implementationGuidance}`;
  * Early exit when no substantial user messages; dynamic maxQuotes
  */
 async function dialogueNode(state) {
-  try {
-    const { context, summary } = state;
+  return tracer.startActiveSpan('commit_story.journal.generate_dialogue', async (span) => {
+    span.setAttribute('commit_story.ai.section_type', 'dialogue');
+    span.setAttribute('gen_ai.operation.name', 'chat');
+    span.setAttribute('gen_ai.provider.name', 'anthropic');
+    span.setAttribute('gen_ai.request.model', 'claude-haiku-4-5-20251001');
+    span.setAttribute('gen_ai.request.temperature', NODE_TEMPERATURES.dialogue);
+    try {
+      const { context, summary } = state;
 
-    // Early exit: skip AI call when no substantial user messages (v1 pattern)
-    const substantialUserMessages = context.metadata?.filterStats?.substantialUserMessages ?? 0;
-    if (substantialUserMessages === 0) {
-      return { dialogue: 'No significant dialogue found for this development session' };
-    }
+      // Early exit: skip AI call when no substantial user messages (v1 pattern)
+      const substantialUserMessages = context.metadata?.filterStats?.substantialUserMessages ?? 0;
+      if (substantialUserMessages === 0) {
+        return { dialogue: 'No significant dialogue found for this development session' };
+      }
 
-    const guidelines = getAllGuidelines();
+      const guidelines = getAllGuidelines();
 
-    // Dynamic maxQuotes: 8% of substantial user messages + 1 (v1 formula)
-    const maxQuotes = Math.min(Math.ceil(substantialUserMessages * 0.08) + 1, 15);
+      // Dynamic maxQuotes: 8% of substantial user messages + 1 (v1 formula)
+      const maxQuotes = Math.min(Math.ceil(substantialUserMessages * 0.08) + 1, 15);
 
-    // Replace {maxQuotes} placeholder in prompt
-    const sectionPrompt = dialoguePrompt.replace(/{maxQuotes}/g, String(maxQuotes));
+      // Replace {maxQuotes} placeholder in prompt
+      const sectionPrompt = dialoguePrompt.replace(/{maxQuotes}/g, String(maxQuotes));
 
-    const systemContent = `${guidelines}
+      const systemContent = `${guidelines}
 
 The summary of this development session is:
 ${summary}
 
 ${sectionPrompt}`;
 
-    const userContent = formatContextForUser(context, { includeSummary: false });
+      const userContent = formatContextForUser(context, { includeSummary: false });
 
-    const result = await getModel(NODE_TEMPERATURES.dialogue).invoke([
-      new SystemMessage(systemContent),
-      new HumanMessage(userContent),
-    ]);
+      const result = await getModel(NODE_TEMPERATURES.dialogue).invoke([
+        new SystemMessage(systemContent),
+        new HumanMessage(userContent),
+      ]);
 
-    return { dialogue: cleanDialogueOutput(result.content.trim()) };
-  } catch (error) {
-    return {
-      dialogue: '[Dialogue extraction failed]',
-      errors: [`Dialogue extraction failed: ${error.message}`],
-    };
-  }
+      if (result.usage_metadata != null) {
+        span.setAttribute('gen_ai.usage.input_tokens', result.usage_metadata.input_tokens);
+        span.setAttribute('gen_ai.usage.output_tokens', result.usage_metadata.output_tokens);
+      }
+
+      return { dialogue: cleanDialogueOutput(result.content.trim()) };
+    } catch (error) {
+      return {
+        dialogue: '[Dialogue extraction failed]',
+        errors: [`Dialogue extraction failed: ${error.message}`],
+      };
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -595,17 +640,33 @@ function getGraph() {
  * @returns {Promise<JournalSections>} Generated journal sections
  */
 export async function generateJournalSections(context) {
-  const graph = getGraph();
+  return tracer.startActiveSpan('commit_story.journal.generate_sections', async (span) => {
+    try {
+      const graph = getGraph();
 
-  const result = await graph.invoke({ context });
+      const result = await graph.invoke({ context });
 
-  return {
-    summary: result.summary || '',
-    dialogue: result.dialogue || '',
-    technicalDecisions: result.technicalDecisions || '',
-    errors: result.errors || [],
-    generatedAt: new Date(),
-  };
+      span.setAttribute('commit_story.journal.sections', [
+        result.summary ? 'summary' : null,
+        result.dialogue ? 'dialogue' : null,
+        result.technicalDecisions ? 'technical_decisions' : null,
+      ].filter(Boolean));
+
+      return {
+        summary: result.summary || '',
+        dialogue: result.dialogue || '',
+        technicalDecisions: result.technicalDecisions || '',
+        errors: result.errors || [],
+        generatedAt: new Date(),
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 // Export node functions and helpers for testing

--- a/src/generators/prompts/guidelines/accessibility.instrumentation.md
+++ b/src/generators/prompts/guidelines/accessibility.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/generators/prompts/guidelines/accessibility.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/generators/prompts/guidelines/anti-hallucination.instrumentation.md
+++ b/src/generators/prompts/guidelines/anti-hallucination.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/generators/prompts/guidelines/anti-hallucination.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/generators/prompts/guidelines/index.instrumentation.md
+++ b/src/generators/prompts/guidelines/index.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/generators/prompts/guidelines/index.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/generators/prompts/sections/daily-summary-prompt.instrumentation.md
+++ b/src/generators/prompts/sections/daily-summary-prompt.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/generators/prompts/sections/daily-summary-prompt.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/generators/prompts/sections/dialogue-prompt.instrumentation.md
+++ b/src/generators/prompts/sections/dialogue-prompt.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/generators/prompts/sections/dialogue-prompt.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/generators/prompts/sections/monthly-summary-prompt.instrumentation.md
+++ b/src/generators/prompts/sections/monthly-summary-prompt.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/generators/prompts/sections/monthly-summary-prompt.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/generators/prompts/sections/summary-prompt.instrumentation.md
+++ b/src/generators/prompts/sections/summary-prompt.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/generators/prompts/sections/summary-prompt.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/generators/prompts/sections/technical-decisions-prompt.instrumentation.md
+++ b/src/generators/prompts/sections/technical-decisions-prompt.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/generators/prompts/sections/technical-decisions-prompt.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/generators/prompts/sections/weekly-summary-prompt.instrumentation.md
+++ b/src/generators/prompts/sections/weekly-summary-prompt.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/generators/prompts/sections/weekly-summary-prompt.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/generators/summary-graph.instrumentation.md
+++ b/src/generators/summary-graph.instrumentation.md
@@ -1,0 +1,42 @@
+# Instrumentation Report: src/generators/summary-graph.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 6
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 8.0K
+- **Output tokens**: 31.2K
+- **Cached tokens**: 23.2K
+
+## Schema Extensions
+- `span.commit_story.journal.daily_summary_node`
+- `span.commit_story.journal.generate_daily_summary`
+- `span.commit_story.journal.weekly_summary_node`
+- `span.commit_story.journal.generate_weekly_summary`
+- `span.commit_story.journal.monthly_summary_node`
+- `span.commit_story.journal.generate_monthly_summary`
+- `commit_story.journal.entries_count`
+- `commit_story.journal.week_label`
+- `commit_story.journal.month_label`
+- `commit_story.journal.summaries_count`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- commit_story.journal.entries_count (type: int, stability: development): Captures the number of journal entries passed into dailySummaryNode and generateDailySummary. No registered key describes 'count of journal entries being summarized' — commit_story.context.messages_count is 'messages collected from sessions' which is semantically different. A new extension key is required.
+- commit_story.journal.week_label (type: string, stability: development): Captures the ISO week string (e.g., '2026-W09') passed to weeklySummaryNode and generateWeeklySummary. No registered key exists for a week period identifier — commit_story.journal.entry_date is YYYY-MM-DD daily granularity only. A new extension key is required.
+- commit_story.journal.month_label (type: string, stability: development): Captures the month string (e.g., '2026-02') passed to monthlySummaryNode and generateMonthlySummary. No registered key exists for a month period identifier. A new extension key is required.
+- commit_story.journal.summaries_count (type: int, stability: development): Captures the count of daily or weekly summaries being consolidated. No registered key precisely matches 'count of summaries being processed as input to a higher-level aggregation'. A new extension key is required.
+- Inner catch blocks in dailySummaryNode, weeklySummaryNode, and monthlySummaryNode are graceful-degradation catches — they return fallback values without rethrowing. Per NDS-007, recordException and setStatus(ERROR) were NOT added to these inner catches. The outer span-level catch handles any unexpected errors that escape the inner catch.
+- LangChain is detected via @langchain/langgraph, @langchain/anthropic, and @langchain/core/messages imports. The LLM API calls (getModel().invoke()) inside the node functions are covered by LangChainInstrumentation auto-instrumentation. Manual spans are still applied to the application-level node and generate functions as COV-001 entry points.
+- getModel, resetModel, formatEntriesForSummary, parseSummarySections, cleanDailySummaryOutput, buildGraph, getGraph, formatDailySummariesForWeekly, parseWeeklySummarySections, cleanWeeklySummaryOutput, buildWeeklyGraph, getWeeklyGraph, formatWeeklySummariesForMonthly, parseMonthlySummarySections, cleanMonthlySummaryOutput, buildMonthlyGraph, getMonthlyGraph — all synchronous or thin synchronous wrappers with no async I/O. Skipped per RST-001 (no spans on synchronous utilities) and RST-004 (unexported internal helpers covered by exported orchestrator spans).
+- Input attributes (entry_date, entries_count, week_label, month_label, summaries_count) are set before the early-return guards inside each span, using state.entries / state.date etc. directly so they are present on all execution paths including the early-exit path.
+
+## Advisory Findings
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

--- a/src/generators/summary-graph.js
+++ b/src/generators/summary-graph.js
@@ -1,12 +1,15 @@
 // ABOUTME: LangGraph StateGraphs for summary generation (daily, weekly, monthly — separate from per-commit journal-graph)
 // ABOUTME: Daily: Narrative, Key Decisions, Open Threads; Weekly: Week in Review, Highlights, Patterns; Monthly: Month in Review, Accomplishments, Growth, Looking Ahead
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { StateGraph, START, END, Annotation } from '@langchain/langgraph';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { SystemMessage, HumanMessage } from '@langchain/core/messages';
 import { dailySummaryPrompt } from './prompts/sections/daily-summary-prompt.js';
 import { weeklySummaryPrompt } from './prompts/sections/weekly-summary-prompt.js';
 import { monthlySummaryPrompt } from './prompts/sections/monthly-summary-prompt.js';
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Summary state definition using LangGraph Annotation API.
@@ -167,44 +170,58 @@ export function cleanDailySummaryOutput(raw) {
  * Reads journal entries and produces a consolidated daily summary.
  */
 export async function dailySummaryNode(state) {
-  const { entries, date } = state;
+  return tracer.startActiveSpan('commit_story.journal.daily_summary_node', async (span) => {
+    span.setAttribute('commit_story.journal.entry_date', state.date ?? '');
+    if (state.entries != null) {
+      span.setAttribute('commit_story.journal.entries_count', state.entries.length);
+    }
+    try {
+      const { entries, date } = state;
 
-  // Early exit: no entries to summarize
-  if (!entries || entries.length === 0) {
-    return {
-      narrative: 'No journal entries found for this date.',
-      keyDecisions: '',
-      openThreads: '',
-      errors: [],
-    };
-  }
+      // Early exit: no entries to summarize
+      if (!entries || entries.length === 0) {
+        return {
+          narrative: 'No journal entries found for this date.',
+          keyDecisions: '',
+          openThreads: '',
+          errors: [],
+        };
+      }
 
-  try {
-    const prompt = dailySummaryPrompt(entries.length);
-    const formattedEntries = formatEntriesForSummary(entries);
+      try {
+        const prompt = dailySummaryPrompt(entries.length);
+        const formattedEntries = formatEntriesForSummary(entries);
 
-    const result = await getModel(0.7).invoke([
-      new SystemMessage(prompt),
-      new HumanMessage(formattedEntries),
-    ]);
+        const result = await getModel(0.7).invoke([
+          new SystemMessage(prompt),
+          new HumanMessage(formattedEntries),
+        ]);
 
-    const cleaned = cleanDailySummaryOutput(result.content);
-    const sections = parseSummarySections(cleaned);
+        const cleaned = cleanDailySummaryOutput(result.content);
+        const sections = parseSummarySections(cleaned);
 
-    return {
-      narrative: sections.narrative,
-      keyDecisions: sections.keyDecisions,
-      openThreads: sections.openThreads,
-      errors: [],
-    };
-  } catch (error) {
-    return {
-      narrative: '[Daily summary generation failed]',
-      keyDecisions: '',
-      openThreads: '',
-      errors: [`Daily summary generation failed: ${error.message}`],
-    };
-  }
+        return {
+          narrative: sections.narrative,
+          keyDecisions: sections.keyDecisions,
+          openThreads: sections.openThreads,
+          errors: [],
+        };
+      } catch (error) {
+        return {
+          narrative: '[Daily summary generation failed]',
+          keyDecisions: '',
+          openThreads: '',
+          errors: [`Daily summary generation failed: ${error.message}`],
+        };
+      }
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -236,16 +253,30 @@ function getGraph() {
  * @returns {Promise<{ narrative: string, keyDecisions: string, openThreads: string, errors: string[], generatedAt: Date }>}
  */
 export async function generateDailySummary(entries, date) {
-  const graph = getGraph();
-  const result = await graph.invoke({ entries, date });
+  return tracer.startActiveSpan('commit_story.journal.generate_daily_summary', async (span) => {
+    span.setAttribute('commit_story.journal.entry_date', date ?? '');
+    if (entries != null) {
+      span.setAttribute('commit_story.journal.entries_count', entries.length);
+    }
+    try {
+      const graph = getGraph();
+      const result = await graph.invoke({ entries, date });
 
-  return {
-    narrative: result.narrative || '',
-    keyDecisions: result.keyDecisions || '',
-    openThreads: result.openThreads || '',
-    errors: result.errors || [],
-    generatedAt: new Date(),
-  };
+      return {
+        narrative: result.narrative || '',
+        keyDecisions: result.keyDecisions || '',
+        openThreads: result.openThreads || '',
+        errors: result.errors || [],
+        generatedAt: new Date(),
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -357,44 +388,58 @@ export function cleanWeeklySummaryOutput(raw) {
  * Reads daily summaries and produces a consolidated weekly summary.
  */
 export async function weeklySummaryNode(state) {
-  const { dailySummaries, weekLabel } = state;
+  return tracer.startActiveSpan('commit_story.journal.weekly_summary_node', async (span) => {
+    span.setAttribute('commit_story.journal.week_label', state.weekLabel ?? '');
+    if (state.dailySummaries != null) {
+      span.setAttribute('commit_story.journal.summaries_count', state.dailySummaries.length);
+    }
+    try {
+      const { dailySummaries, weekLabel } = state;
 
-  // Early exit: no daily summaries to consolidate
-  if (!dailySummaries || dailySummaries.length === 0) {
-    return {
-      weekInReview: 'No daily summaries found for this week.',
-      highlights: '',
-      patterns: '',
-      errors: [],
-    };
-  }
+      // Early exit: no daily summaries to consolidate
+      if (!dailySummaries || dailySummaries.length === 0) {
+        return {
+          weekInReview: 'No daily summaries found for this week.',
+          highlights: '',
+          patterns: '',
+          errors: [],
+        };
+      }
 
-  try {
-    const prompt = weeklySummaryPrompt(dailySummaries.length);
-    const formattedSummaries = formatDailySummariesForWeekly(dailySummaries);
+      try {
+        const prompt = weeklySummaryPrompt(dailySummaries.length);
+        const formattedSummaries = formatDailySummariesForWeekly(dailySummaries);
 
-    const result = await getModel(0.7).invoke([
-      new SystemMessage(prompt),
-      new HumanMessage(formattedSummaries),
-    ]);
+        const result = await getModel(0.7).invoke([
+          new SystemMessage(prompt),
+          new HumanMessage(formattedSummaries),
+        ]);
 
-    const cleaned = cleanWeeklySummaryOutput(result.content);
-    const sections = parseWeeklySummarySections(cleaned);
+        const cleaned = cleanWeeklySummaryOutput(result.content);
+        const sections = parseWeeklySummarySections(cleaned);
 
-    return {
-      weekInReview: sections.weekInReview,
-      highlights: sections.highlights,
-      patterns: sections.patterns,
-      errors: [],
-    };
-  } catch (error) {
-    return {
-      weekInReview: '[Weekly summary generation failed]',
-      highlights: '',
-      patterns: '',
-      errors: [`Weekly summary generation failed: ${error.message}`],
-    };
-  }
+        return {
+          weekInReview: sections.weekInReview,
+          highlights: sections.highlights,
+          patterns: sections.patterns,
+          errors: [],
+        };
+      } catch (error) {
+        return {
+          weekInReview: '[Weekly summary generation failed]',
+          highlights: '',
+          patterns: '',
+          errors: [`Weekly summary generation failed: ${error.message}`],
+        };
+      }
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -426,16 +471,30 @@ function getWeeklyGraph() {
  * @returns {Promise<{ weekInReview: string, highlights: string, patterns: string, errors: string[], generatedAt: Date }>}
  */
 export async function generateWeeklySummary(dailySummaries, weekLabel) {
-  const graph = getWeeklyGraph();
-  const result = await graph.invoke({ dailySummaries, weekLabel });
+  return tracer.startActiveSpan('commit_story.journal.generate_weekly_summary', async (span) => {
+    span.setAttribute('commit_story.journal.week_label', weekLabel ?? '');
+    if (dailySummaries != null) {
+      span.setAttribute('commit_story.journal.summaries_count', dailySummaries.length);
+    }
+    try {
+      const graph = getWeeklyGraph();
+      const result = await graph.invoke({ dailySummaries, weekLabel });
 
-  return {
-    weekInReview: result.weekInReview || '',
-    highlights: result.highlights || '',
-    patterns: result.patterns || '',
-    errors: result.errors || [],
-    generatedAt: new Date(),
-  };
+      return {
+        weekInReview: result.weekInReview || '',
+        highlights: result.highlights || '',
+        patterns: result.patterns || '',
+        errors: result.errors || [],
+        generatedAt: new Date(),
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -549,47 +608,61 @@ export function cleanMonthlySummaryOutput(raw) {
  * Reads weekly summaries and produces a consolidated monthly summary.
  */
 export async function monthlySummaryNode(state) {
-  const { weeklySummaries, monthLabel } = state;
+  return tracer.startActiveSpan('commit_story.journal.monthly_summary_node', async (span) => {
+    span.setAttribute('commit_story.journal.month_label', state.monthLabel ?? '');
+    if (state.weeklySummaries != null) {
+      span.setAttribute('commit_story.journal.summaries_count', state.weeklySummaries.length);
+    }
+    try {
+      const { weeklySummaries, monthLabel } = state;
 
-  // Early exit: no weekly summaries to consolidate
-  if (!weeklySummaries || weeklySummaries.length === 0) {
-    return {
-      monthInReview: 'No weekly summaries found for this month.',
-      accomplishments: '',
-      growth: '',
-      lookingAhead: '',
-      errors: [],
-    };
-  }
+      // Early exit: no weekly summaries to consolidate
+      if (!weeklySummaries || weeklySummaries.length === 0) {
+        return {
+          monthInReview: 'No weekly summaries found for this month.',
+          accomplishments: '',
+          growth: '',
+          lookingAhead: '',
+          errors: [],
+        };
+      }
 
-  try {
-    const prompt = monthlySummaryPrompt(weeklySummaries.length);
-    const formattedSummaries = formatWeeklySummariesForMonthly(weeklySummaries);
+      try {
+        const prompt = monthlySummaryPrompt(weeklySummaries.length);
+        const formattedSummaries = formatWeeklySummariesForMonthly(weeklySummaries);
 
-    const result = await getModel(0.7).invoke([
-      new SystemMessage(prompt),
-      new HumanMessage(formattedSummaries),
-    ]);
+        const result = await getModel(0.7).invoke([
+          new SystemMessage(prompt),
+          new HumanMessage(formattedSummaries),
+        ]);
 
-    const cleaned = cleanMonthlySummaryOutput(result.content);
-    const sections = parseMonthlySummarySections(cleaned);
+        const cleaned = cleanMonthlySummaryOutput(result.content);
+        const sections = parseMonthlySummarySections(cleaned);
 
-    return {
-      monthInReview: sections.monthInReview,
-      accomplishments: sections.accomplishments,
-      growth: sections.growth,
-      lookingAhead: sections.lookingAhead,
-      errors: [],
-    };
-  } catch (error) {
-    return {
-      monthInReview: '[Monthly summary generation failed]',
-      accomplishments: '',
-      growth: '',
-      lookingAhead: '',
-      errors: [`Monthly summary generation failed: ${error.message}`],
-    };
-  }
+        return {
+          monthInReview: sections.monthInReview,
+          accomplishments: sections.accomplishments,
+          growth: sections.growth,
+          lookingAhead: sections.lookingAhead,
+          errors: [],
+        };
+      } catch (error) {
+        return {
+          monthInReview: '[Monthly summary generation failed]',
+          accomplishments: '',
+          growth: '',
+          lookingAhead: '',
+          errors: [`Monthly summary generation failed: ${error.message}`],
+        };
+      }
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -621,15 +694,29 @@ function getMonthlyGraph() {
  * @returns {Promise<{ monthInReview: string, accomplishments: string, growth: string, lookingAhead: string, errors: string[], generatedAt: Date }>}
  */
 export async function generateMonthlySummary(weeklySummaries, monthLabel) {
-  const graph = getMonthlyGraph();
-  const result = await graph.invoke({ weeklySummaries, monthLabel });
+  return tracer.startActiveSpan('commit_story.journal.generate_monthly_summary', async (span) => {
+    span.setAttribute('commit_story.journal.month_label', monthLabel ?? '');
+    if (weeklySummaries != null) {
+      span.setAttribute('commit_story.journal.summaries_count', weeklySummaries.length);
+    }
+    try {
+      const graph = getMonthlyGraph();
+      const result = await graph.invoke({ weeklySummaries, monthLabel });
 
-  return {
-    monthInReview: result.monthInReview || '',
-    accomplishments: result.accomplishments || '',
-    growth: result.growth || '',
-    lookingAhead: result.lookingAhead || '',
-    errors: result.errors || [],
-    generatedAt: new Date(),
-  };
+      return {
+        monthInReview: result.monthInReview || '',
+        accomplishments: result.accomplishments || '',
+        growth: result.growth || '',
+        lookingAhead: result.lookingAhead || '',
+        errors: result.errors || [],
+        generatedAt: new Date(),
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }

--- a/src/index.instrumentation.md
+++ b/src/index.instrumentation.md
@@ -1,0 +1,22 @@
+# Instrumentation Report: src/index.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 1
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 6.2K
+- **Output tokens**: 13.2K
+
+## Schema Extensions
+- `span.commit_story.cli.main`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- span.commit_story.cli.main is a new span name for the CLI entry point in src/index.js. All existing schema span names (commit_story.mcp.main and the full list of already-used names) are taken; this file's main() is the CLI orchestrator, distinct from the MCP server entry point, so a new name is warranted. The namespace prefix commit_story is preserved.
+- main() sets vcs.ref.head.revision with the commitRef value (the git commit reference passed at the CLI) and conditionally sets commit_story.git.subcommand with the parsed subcommand. Both are registered schema keys — no new attribute declarations are needed.
+- Known limitation: main() calls process.exit() in multiple code paths (validation failures, skip conditions, success). process.exit() bypasses the finally block, so the span will not be ended on those paths. This is an inherent limitation of the process.exit() pattern in the original code; no span.end() calls are added before individual process.exit() calls per the pre-instrumentation analysis.
+- handleSummarize() is an unexported async function that calls process.exit() directly in its body on multiple paths. It is skipped on two grounds: RST-004 (unexported helper whose execution path is covered by the parent main() span) and RST-006 (direct process.exit() calls in the function body would bypass the span finally block causing span leaks).
+- parseArgs(), showHelp(), isGitRepository(), isValidCommitRef(), validateEnvironment(), and getPreviousCommitTime() are all synchronous functions with no async I/O — skipped per RST-001 (no spans on pure synchronous utilities).
+- The inner try/catch block inside main() that wraps triggerAutoSummaries() is a graceful-degradation catch — it catches errors and logs a warning without rethrowing. Per NDS-007, recordException() and setStatus(ERROR) are not added to this inner catch. The outer span-level catch (COV-003) handles unexpected errors that escape the main flow.

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@
  *   2 - Skipped (journal-only commit, empty merge)
  */
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import './utils/config.js'; // Load environment variables first
 import './traceloop-init.js'; // Register traceloop auto-instrumentation (if enabled)
 import { config } from './utils/config.js';
@@ -28,6 +29,8 @@ import { isJournalEntriesOnlyCommit, isMergeCommit, shouldSkipMergeCommit, isSaf
 import { triggerAutoSummaries } from './managers/auto-summarize.js';
 import { parseSummarizeArgs, runSummarize, runWeeklySummarize, runMonthlySummarize, showSummarizeHelp } from './commands/summarize.js';
 import logger from './logger.js';
+
+const tracer = trace.getTracer('commit-story');
 
 /** Exit codes */
 const EXIT_SUCCESS = 0;
@@ -336,139 +339,153 @@ async function handleSummarize(args) {
  * Main entry point
  */
 async function main() {
-  const { subcommand, commitRef, help, subcommandArgs } = parseArgs();
-
-  if (DEBUG) {
-    logger.level = 'debug';
-  }
-
-  // Show help if requested
-  if (help) {
-    showHelp();
-    process.exit(EXIT_SUCCESS);
-  }
-
-  // Route to subcommand handlers
-  if (subcommand === 'summarize') {
-    await handleSummarize(subcommandArgs);
-    return;
-  }
-
-  logger.debug('Starting commit-story');
-  logger.debug({ commitRef }, 'Commit ref');
-
-  // Validate git repository
-  if (!isGitRepository()) {
-    logger.error('Not a git repository — run commit-story from within a git repository');
-    process.exit(EXIT_ERROR);
-  }
-
-  // Validate commit reference
-  if (!isValidCommitRef(commitRef)) {
-    logger.error({ commitRef }, 'Invalid commit reference — check that the commit exists: git log --oneline');
-    process.exit(EXIT_ERROR);
-  }
-
-  // Validate environment
-  if (!validateEnvironment()) {
-    process.exit(EXIT_ERROR);
-  }
-
-  // Check skip conditions BEFORE expensive context collection
-  logger.debug('Checking skip conditions');
-
-  // Skip journal-entries-only commits
-  if (isJournalEntriesOnlyCommit(commitRef)) {
-    logger.info('Skipping: only journal entries changed');
-    process.exit(EXIT_SKIPPED);
-  }
-
-  // Check for merge commits
-  const mergeInfo = isMergeCommit(commitRef);
-  logger.debug({ isMerge: mergeInfo.isMerge }, 'Merge commit check');
-
-  // Gather context
-  logger.debug('Gathering context');
-  const context = await gatherContextForCommit(commitRef);
-  logger.debug({
-    messageCount: context.chat?.messageCount || 0,
-    diffLength: context.commit?.diff?.length || 0,
-  }, 'Context gathered');
-
-  // Skip empty merge commits (no chat AND no diff)
-  if (mergeInfo.isMerge) {
-    const hasChat = context.chat && context.chat.messageCount > 0;
-    const hasDiff = context.commit && context.commit.diff && context.commit.diff.trim().length > 0;
-
-    if (!hasChat && !hasDiff) {
-      logger.info('Skipping: merge commit with no changes');
-      process.exit(EXIT_SKIPPED);
-    }
-    logger.debug({ hasChat, hasDiff }, 'Processing merge commit');
-  }
-
-  // Generate journal sections
-  logger.debug('Generating journal sections');
-  const sections = await generateJournalSections(context);
-  logger.debug({
-    hasSummary: !!sections.summary,
-    hasDialogue: !!sections.dialogue,
-    hasTechnical: !!sections.technicalDecisions,
-    errors: sections.errors?.length || 0,
-  }, 'Sections generated');
-
-  // Discover reflections for time window
-  const previousCommitTime = getPreviousCommitTime(commitRef);
-  const currentCommitTime = context.commit.timestamp;
-  logger.debug({ from: previousCommitTime, to: currentCommitTime }, 'Reflection window');
-
-  const reflections = await discoverReflections(previousCommitTime, currentCommitTime);
-  logger.debug({ count: reflections.length }, 'Reflections found');
-
-  // Save journal entry
-  logger.debug('Saving journal entry');
-  const savedPath = await saveJournalEntry(sections, context.commit, reflections, '.', { debug: (msg) => logger.debug(msg) });
-
-  logger.info({ path: savedPath }, 'Journal entry saved');
-
-  // Log any generation errors
-  if (sections.errors && sections.errors.length > 0) {
-    for (const err of sections.errors) {
-      logger.warn({ error: err }, 'Section generation issue');
-    }
-  }
-
-  // Auto-generate daily and weekly summaries for unsummarized past days/weeks
-  if (config.autoSummarize) {
-    logger.debug('Checking for unsummarized days and weeks');
+  return tracer.startActiveSpan('commit_story.cli.main', async (span) => {
     try {
-      const summaryResult = await triggerAutoSummaries('.', {
-        onProgress: (msg) => logger.debug(msg),
-      });
+      const { subcommand, commitRef, help, subcommandArgs } = parseArgs();
+      span.setAttribute('vcs.ref.head.revision', commitRef);
+      if (subcommand != null) {
+        span.setAttribute('commit_story.git.subcommand', subcommand);
+      }
 
-      if (summaryResult.generated.length > 0) {
-        const dailyCount = summaryResult.generated.filter(p => p.includes('daily')).length;
-        const weeklyCount = summaryResult.generated.filter(p => p.includes('weekly')).length;
-        const monthlyCount = summaryResult.generated.filter(p => p.includes('monthly')).length;
-        logger.info({ dailyCount, weeklyCount, monthlyCount }, 'Auto-generated summaries');
-        for (const path of summaryResult.generated) {
-          logger.debug({ path }, 'Summary path');
+      if (DEBUG) {
+        logger.level = 'debug';
+      }
+
+      // Show help if requested
+      if (help) {
+        showHelp();
+        process.exit(EXIT_SUCCESS);
+      }
+
+      // Route to subcommand handlers
+      if (subcommand === 'summarize') {
+        await handleSummarize(subcommandArgs);
+        return;
+      }
+
+      logger.debug('Starting commit-story');
+      logger.debug({ commitRef }, 'Commit ref');
+
+      // Validate git repository
+      if (!isGitRepository()) {
+        logger.error('Not a git repository — run commit-story from within a git repository');
+        process.exit(EXIT_ERROR);
+      }
+
+      // Validate commit reference
+      if (!isValidCommitRef(commitRef)) {
+        logger.error({ commitRef }, 'Invalid commit reference — check that the commit exists: git log --oneline');
+        process.exit(EXIT_ERROR);
+      }
+
+      // Validate environment
+      if (!validateEnvironment()) {
+        process.exit(EXIT_ERROR);
+      }
+
+      // Check skip conditions BEFORE expensive context collection
+      logger.debug('Checking skip conditions');
+
+      // Skip journal-entries-only commits
+      if (isJournalEntriesOnlyCommit(commitRef)) {
+        logger.info('Skipping: only journal entries changed');
+        process.exit(EXIT_SKIPPED);
+      }
+
+      // Check for merge commits
+      const mergeInfo = isMergeCommit(commitRef);
+      logger.debug({ isMerge: mergeInfo.isMerge }, 'Merge commit check');
+
+      // Gather context
+      logger.debug('Gathering context');
+      const context = await gatherContextForCommit(commitRef);
+      logger.debug({
+        messageCount: context.chat?.messageCount || 0,
+        diffLength: context.commit?.diff?.length || 0,
+      }, 'Context gathered');
+
+      // Skip empty merge commits (no chat AND no diff)
+      if (mergeInfo.isMerge) {
+        const hasChat = context.chat && context.chat.messageCount > 0;
+        const hasDiff = context.commit && context.commit.diff && context.commit.diff.trim().length > 0;
+
+        if (!hasChat && !hasDiff) {
+          logger.info('Skipping: merge commit with no changes');
+          process.exit(EXIT_SKIPPED);
+        }
+        logger.debug({ hasChat, hasDiff }, 'Processing merge commit');
+      }
+
+      // Generate journal sections
+      logger.debug('Generating journal sections');
+      const sections = await generateJournalSections(context);
+      logger.debug({
+        hasSummary: !!sections.summary,
+        hasDialogue: !!sections.dialogue,
+        hasTechnical: !!sections.technicalDecisions,
+        errors: sections.errors?.length || 0,
+      }, 'Sections generated');
+
+      // Discover reflections for time window
+      const previousCommitTime = getPreviousCommitTime(commitRef);
+      const currentCommitTime = context.commit.timestamp;
+      logger.debug({ from: previousCommitTime, to: currentCommitTime }, 'Reflection window');
+
+      const reflections = await discoverReflections(previousCommitTime, currentCommitTime);
+      logger.debug({ count: reflections.length }, 'Reflections found');
+
+      // Save journal entry
+      logger.debug('Saving journal entry');
+      const savedPath = await saveJournalEntry(sections, context.commit, reflections, '.', { debug: (msg) => logger.debug(msg) });
+
+      logger.info({ path: savedPath }, 'Journal entry saved');
+
+      // Log any generation errors
+      if (sections.errors && sections.errors.length > 0) {
+        for (const err of sections.errors) {
+          logger.warn({ error: err }, 'Section generation issue');
         }
       }
 
-      if (summaryResult.failed.length > 0) {
-        logger.warn({ count: summaryResult.failed.length }, 'Failed to auto-generate summaries');
-        for (const dateStr of summaryResult.failed) {
-          logger.warn({ date: dateStr }, 'Failed summary date');
+      // Auto-generate daily and weekly summaries for unsummarized past days/weeks
+      if (config.autoSummarize) {
+        logger.debug('Checking for unsummarized days and weeks');
+        try {
+          const summaryResult = await triggerAutoSummaries('.', {
+            onProgress: (msg) => logger.debug(msg),
+          });
+
+          if (summaryResult.generated.length > 0) {
+            const dailyCount = summaryResult.generated.filter(p => p.includes('daily')).length;
+            const weeklyCount = summaryResult.generated.filter(p => p.includes('weekly')).length;
+            const monthlyCount = summaryResult.generated.filter(p => p.includes('monthly')).length;
+            logger.info({ dailyCount, weeklyCount, monthlyCount }, 'Auto-generated summaries');
+            for (const path of summaryResult.generated) {
+              logger.debug({ path }, 'Summary path');
+            }
+          }
+
+          if (summaryResult.failed.length > 0) {
+            logger.warn({ count: summaryResult.failed.length }, 'Failed to auto-generate summaries');
+            for (const dateStr of summaryResult.failed) {
+              logger.warn({ date: dateStr }, 'Failed summary date');
+            }
+          }
+        } catch (err) {
+          // Auto-summarize failures should not block the main flow
+          logger.warn(err, 'Auto-summarize error');
         }
       }
-    } catch (err) {
-      // Auto-summarize failures should not block the main flow
-      logger.warn(err, 'Auto-summarize error');
+
+      process.exit(EXIT_SUCCESS);
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  process.exit(EXIT_SUCCESS);
+  });
 }
 
 // Run main function

--- a/src/integrators/context-integrator.instrumentation.md
+++ b/src/integrators/context-integrator.instrumentation.md
@@ -1,0 +1,31 @@
+# Instrumentation Report: src/integrators/context-integrator.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 1
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 3.4K
+- **Output tokens**: 9.3K
+- **Cached tokens**: 24.3K
+
+## Schema Extensions
+- `span.commit_story.context.gather_context`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- gatherContextForCommit is the COV-001 entry point orchestrating all context collection. It receives a span named 'commit_story.context.gather_context' — no schema span existed for this orchestrating role (the schema spans for context cover the sub-operations like collect_messages, which are already instrumented in their respective callee files).
+- formatContextForPrompt is a pure synchronous data transformation (no I/O, no async) — skipped per RST-001.
+- getContextSummary is a pure synchronous data transformation returning a summary object — skipped per RST-001.
+- All six attributes set on the gather_context span (vcs.ref.head.revision, commit_story.commit.message, commit_story.filter.messages_before, commit_story.filter.messages_after, commit_story.context.sessions_count, commit_story.context.messages_count) are already registered in the schema — no new attribute keys were declared.
+- commit_story.commit.message is set from commitData.message (a git commit subject line from an external source). CDQ-006 isRecording() guards do not apply to COV-001 entry point spans per the exemption rule.
+- vcs.ref.head.revision is set before any awaited calls so it is present even if an early error occurs in getCommitData.
+
+## Advisory Findings
+- CDQ-007 (Attribute Data Quality):63: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):64: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):65: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):66: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):67: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

--- a/src/integrators/context-integrator.js
+++ b/src/integrators/context-integrator.js
@@ -6,11 +6,14 @@
  * token budget limits, and sensitive data redaction.
  */
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { getCommitData, getPreviousCommitTime } from '../collectors/git-collector.js';
 import { collectChatMessages } from '../collectors/claude-collector.js';
 import { filterMessages, groupFilteredBySession } from './filters/message-filter.js';
 import { applyTokenBudget, estimateTokens } from './filters/token-filter.js';
 import { applySensitiveFilter } from './filters/sensitive-filter.js';
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Gather all context for a commit
@@ -24,86 +27,103 @@ import { applySensitiveFilter } from './filters/sensitive-filter.js';
  * @returns {Promise<Context>} Gathered and filtered context
  */
 export async function gatherContextForCommit(commitRef = 'HEAD', options = {}) {
-  const {
-    repoPath = process.cwd(),
-    tokenBudget = 150000,
-    diffBudget = 50000,
-    chatBudget = 80000,
-    redactEmails = false,
-  } = options;
+  return tracer.startActiveSpan('commit_story.context.gather_context', async (span) => {
+    span.setAttribute('vcs.ref.head.revision', commitRef);
+    try {
+      const {
+        repoPath = process.cwd(),
+        tokenBudget = 150000,
+        diffBudget = 50000,
+        chatBudget = 80000,
+        redactEmails = false,
+      } = options;
 
-  // 1. Collect git data
-  const commitData = await getCommitData(commitRef);
+      // 1. Collect git data
+      const commitData = await getCommitData(commitRef);
 
-  // 2. Get previous commit time for chat window
-  const previousCommitTime = await getPreviousCommitTime(commitRef);
+      // 2. Get previous commit time for chat window
+      const previousCommitTime = await getPreviousCommitTime(commitRef);
 
-  // 3. Collect chat messages
-  let chatData;
-  if (previousCommitTime) {
-    chatData = await collectChatMessages(repoPath, commitData.timestamp, previousCommitTime);
-  } else {
-    // First commit - use 24 hours before as window
-    const dayBefore = new Date(commitData.timestamp.getTime() - 24 * 60 * 60 * 1000);
-    chatData = await collectChatMessages(repoPath, commitData.timestamp, dayBefore);
-  }
+      // 3. Collect chat messages
+      let chatData;
+      if (previousCommitTime) {
+        chatData = await collectChatMessages(repoPath, commitData.timestamp, previousCommitTime);
+      } else {
+        // First commit - use 24 hours before as window
+        const dayBefore = new Date(commitData.timestamp.getTime() - 24 * 60 * 60 * 1000);
+        chatData = await collectChatMessages(repoPath, commitData.timestamp, dayBefore);
+      }
 
-  // 4. Filter chat messages
-  const { messages: filteredMessages, stats: filterStats } = filterMessages(chatData.messages);
+      // 4. Filter chat messages
+      const { messages: filteredMessages, stats: filterStats } = filterMessages(chatData.messages);
 
-  // 5. Group filtered messages by session
-  const filteredSessions = groupFilteredBySession(filteredMessages);
+      // 5. Group filtered messages by session
+      const filteredSessions = groupFilteredBySession(filteredMessages);
 
-  // 6. Build initial context object
-  let context = {
-    commit: {
-      hash: commitData.hash,
-      shortHash: commitData.shortHash,
-      message: commitData.message,
-      subject: commitData.subject,
-      author: commitData.author,
-      authorEmail: commitData.authorEmail,
-      timestamp: commitData.timestamp,
-      diff: commitData.diff,
-      isMerge: commitData.isMerge,
-      parentCount: commitData.parentCount,
-    },
-    chat: {
-      messages: filteredMessages,
-      sessions: filteredSessions,
-      messageCount: filteredMessages.length,
-      sessionCount: filteredSessions.size,
-    },
-    metadata: {
-      previousCommitTime,
-      timeWindow: {
-        start: previousCommitTime || new Date(commitData.timestamp.getTime() - 24 * 60 * 60 * 1000),
-        end: commitData.timestamp,
-      },
-      filterStats: {
-        totalMessages: filterStats.total,
-        filteredMessages: filterStats.filtered,
-        preservedMessages: filterStats.preserved,
-        substantialUserMessages: filterStats.substantialUserMessages,
-        filterReasons: filterStats.byReason,
-      },
-      tokenEstimate: 0, // Will be calculated after budget applied
-    },
-  };
+      span.setAttribute('commit_story.commit.message', commitData.message);
+      span.setAttribute('commit_story.filter.messages_before', filterStats.total);
+      span.setAttribute('commit_story.filter.messages_after', filterStats.preserved);
+      span.setAttribute('commit_story.context.sessions_count', filteredSessions.size);
+      span.setAttribute('commit_story.context.messages_count', filteredMessages.length);
 
-  // 7. Apply token budget limits
-  context = applyTokenBudget(context, {
-    totalBudget: tokenBudget,
-    diffBudget,
-    chatBudget,
+      // 6. Build initial context object
+      let context = {
+        commit: {
+          hash: commitData.hash,
+          shortHash: commitData.shortHash,
+          message: commitData.message,
+          subject: commitData.subject,
+          author: commitData.author,
+          authorEmail: commitData.authorEmail,
+          timestamp: commitData.timestamp,
+          diff: commitData.diff,
+          isMerge: commitData.isMerge,
+          parentCount: commitData.parentCount,
+        },
+        chat: {
+          messages: filteredMessages,
+          sessions: filteredSessions,
+          messageCount: filteredMessages.length,
+          sessionCount: filteredSessions.size,
+        },
+        metadata: {
+          previousCommitTime,
+          timeWindow: {
+            start: previousCommitTime || new Date(commitData.timestamp.getTime() - 24 * 60 * 60 * 1000),
+            end: commitData.timestamp,
+          },
+          filterStats: {
+            totalMessages: filterStats.total,
+            filteredMessages: filterStats.filtered,
+            preservedMessages: filterStats.preserved,
+            substantialUserMessages: filterStats.substantialUserMessages,
+            filterReasons: filterStats.byReason,
+          },
+          tokenEstimate: 0, // Will be calculated after budget applied
+        },
+      };
+
+      // 7. Apply token budget limits
+      context = applyTokenBudget(context, {
+        totalBudget: tokenBudget,
+        diffBudget,
+        chatBudget,
+      });
+
+      // 8. Apply sensitive data redaction
+      context = applySensitiveFilter(context, {
+        redactEmails,
+      });
+
+      return context;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
   });
-
-  // 8. Apply sensitive data redaction
-  context = applySensitiveFilter(context, {
-    redactEmails,
-  });
-
-  return context;
 }
 
 /**

--- a/src/integrators/filters/message-filter.instrumentation.md
+++ b/src/integrators/filters/message-filter.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/integrators/filters/message-filter.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/integrators/filters/sensitive-filter.instrumentation.md
+++ b/src/integrators/filters/sensitive-filter.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/integrators/filters/sensitive-filter.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/integrators/filters/token-filter.instrumentation.md
+++ b/src/integrators/filters/token-filter.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/integrators/filters/token-filter.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/logger.instrumentation.md
+++ b/src/logger.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/logger.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/managers/auto-summarize.instrumentation.md
+++ b/src/managers/auto-summarize.instrumentation.md
@@ -1,0 +1,31 @@
+# Instrumentation Report: src/managers/auto-summarize.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 3
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 3.5K
+- **Output tokens**: 5.6K
+
+## Schema Extensions
+- `span.commit_story.commands.trigger_auto_summaries`
+- `span.commit_story.commands.trigger_auto_weekly_summaries`
+- `span.commit_story.commands.trigger_auto_monthly_summaries`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- triggerAutoSummaries, triggerAutoWeeklySummaries, and triggerAutoMonthlySummaries are all COV-001 exported entry points and each received a span. The schema-defined span names commit_story.commands.run_summarize, run_weekly_summarize, and run_monthly_summarize were already taken by earlier files, so new names were invented: commit_story.commands.trigger_auto_summaries, trigger_auto_weekly_summaries, trigger_auto_monthly_summaries.
+- getErrorMessage is a pure synchronous helper with no I/O — skipped per RST-001 (no spans on synchronous utilities) and RST-004 (unexported function whose execution path is covered by the exported orchestrator spans).
+- The inner catch blocks inside each loop do not rethrow — they push to result.failed/result.errors and continue. These are graceful-degradation catches per NDS-007, so recordException and setStatus(ERROR) were not added to them. The outer span-level catch handles unexpected errors that propagate out of the function.
+- All attributes used (commit_story.journal.unsummarized_days_count, commit_story.journal.unsummarized_weeks_count, commit_story.journal.unsummarized_months_count, commit_story.journal.summaries_count) are already registered in the schema — no new attribute extensions needed.
+- In triggerAutoSummaries, the summaries_count attribute is set at both the early-return path (when failures exist) and the final return path (summing daily + weekly + monthly generated counts), ensuring the attribute is present on all exit paths.
+
+## Advisory Findings
+- CDQ-007 (Attribute Data Quality):29: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):119: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):181: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

--- a/src/managers/auto-summarize.js
+++ b/src/managers/auto-summarize.js
@@ -1,8 +1,11 @@
 // ABOUTME: Auto-trigger logic for daily, weekly, and monthly summaries after journal entry creation
 // ABOUTME: Detects unsummarized past days/weeks/months and generates summaries with progress reporting
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { findUnsummarizedDays, findUnsummarizedWeeks, findUnsummarizedMonths } from '../utils/summary-detector.js';
 import { generateAndSaveDailySummary, generateAndSaveWeeklySummary, generateAndSaveMonthlySummary } from './summary-manager.js';
+
+const tracer = trace.getTracer('commit-story');
 
 function getErrorMessage(err) {
   return err instanceof Error ? err.message : String(err);
@@ -18,72 +21,85 @@ function getErrorMessage(err) {
  * @returns {Promise<{ generated: string[], skipped: string[], failed: string[], errors: string[] }>}
  */
 export async function triggerAutoSummaries(basePath = '.', options = {}) {
-  const { onProgress } = options;
-
-  const unsummarizedDays = await findUnsummarizedDays(basePath);
-
-  const result = {
-    generated: [],
-    skipped: [],
-    failed: [],
-    errors: [],
-  };
-
-  for (const dateStr of unsummarizedDays) {
-    const date = new Date(
-      parseInt(dateStr.slice(0, 4)),
-      parseInt(dateStr.slice(5, 7)) - 1,
-      parseInt(dateStr.slice(8, 10)),
-    );
-
+  return tracer.startActiveSpan('commit_story.commands.trigger_auto_summaries', async (span) => {
     try {
-      const summaryResult = await generateAndSaveDailySummary(date, basePath);
+      const { onProgress } = options;
 
-      if (summaryResult.saved) {
-        result.generated.push(summaryResult.path);
-        if (onProgress) {
-          onProgress(`Generated daily summary for ${dateStr}`);
-        }
+      const unsummarizedDays = await findUnsummarizedDays(basePath);
+      span.setAttribute('commit_story.journal.unsummarized_days_count', unsummarizedDays.length);
 
-        // Track errors from generation (partial issues like LLM timeouts)
-        if (summaryResult.errors && summaryResult.errors.length > 0) {
-          for (const err of summaryResult.errors) {
-            result.errors.push(`${dateStr}: ${err}`);
+      const result = {
+        generated: [],
+        skipped: [],
+        failed: [],
+        errors: [],
+      };
+
+      for (const dateStr of unsummarizedDays) {
+        const date = new Date(
+          parseInt(dateStr.slice(0, 4)),
+          parseInt(dateStr.slice(5, 7)) - 1,
+          parseInt(dateStr.slice(8, 10)),
+        );
+
+        try {
+          const summaryResult = await generateAndSaveDailySummary(date, basePath);
+
+          if (summaryResult.saved) {
+            result.generated.push(summaryResult.path);
+            if (onProgress) {
+              onProgress(`Generated daily summary for ${dateStr}`);
+            }
+
+            // Track errors from generation (partial issues like LLM timeouts)
+            if (summaryResult.errors && summaryResult.errors.length > 0) {
+              for (const err of summaryResult.errors) {
+                result.errors.push(`${dateStr}: ${err}`);
+              }
+            }
+          } else {
+            result.skipped.push(dateStr);
+          }
+        } catch (err) {
+          result.failed.push(dateStr);
+          result.errors.push(`${dateStr}: ${getErrorMessage(err)}`);
+          if (onProgress) {
+            onProgress(`Failed to generate summary for ${dateStr}: ${getErrorMessage(err)}`);
           }
         }
-      } else {
-        result.skipped.push(dateStr);
       }
-    } catch (err) {
-      result.failed.push(dateStr);
-      result.errors.push(`${dateStr}: ${getErrorMessage(err)}`);
-      if (onProgress) {
-        onProgress(`Failed to generate summary for ${dateStr}: ${getErrorMessage(err)}`);
+
+      // Skip higher-cadence rollups if daily generation had failures —
+      // prevents locking in incomplete weekly/monthly via duplicate detection
+      if (result.failed.length > 0) {
+        if (onProgress) {
+          onProgress('Skipped weekly/monthly auto-summaries because daily generation had failures');
+        }
+        span.setAttribute('commit_story.journal.summaries_count', result.generated.length);
+        return result;
       }
+
+      // After daily summaries are generated, check for unsummarized weeks
+      const weeklyResult = await triggerAutoWeeklySummaries(basePath, options);
+
+      // After weekly summaries are generated, check for unsummarized months
+      const monthlyResult = await triggerAutoMonthlySummaries(basePath, options);
+
+      span.setAttribute('commit_story.journal.summaries_count', result.generated.length + weeklyResult.generated.length + monthlyResult.generated.length);
+      return {
+        generated: [...result.generated, ...weeklyResult.generated, ...monthlyResult.generated],
+        skipped: [...result.skipped, ...weeklyResult.skipped, ...monthlyResult.skipped],
+        failed: [...result.failed, ...weeklyResult.failed, ...monthlyResult.failed],
+        errors: [...result.errors, ...weeklyResult.errors, ...monthlyResult.errors],
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  // Skip higher-cadence rollups if daily generation had failures —
-  // prevents locking in incomplete weekly/monthly via duplicate detection
-  if (result.failed.length > 0) {
-    if (onProgress) {
-      onProgress('Skipped weekly/monthly auto-summaries because daily generation had failures');
-    }
-    return result;
-  }
-
-  // After daily summaries are generated, check for unsummarized weeks
-  const weeklyResult = await triggerAutoWeeklySummaries(basePath, options);
-
-  // After weekly summaries are generated, check for unsummarized months
-  const monthlyResult = await triggerAutoMonthlySummaries(basePath, options);
-
-  return {
-    generated: [...result.generated, ...weeklyResult.generated, ...monthlyResult.generated],
-    skipped: [...result.skipped, ...weeklyResult.skipped, ...monthlyResult.skipped],
-    failed: [...result.failed, ...weeklyResult.failed, ...monthlyResult.failed],
-    errors: [...result.errors, ...weeklyResult.errors, ...monthlyResult.errors],
-  };
+  });
 }
 
 /**
@@ -95,45 +111,57 @@ export async function triggerAutoSummaries(basePath = '.', options = {}) {
  * @returns {Promise<{ generated: string[], skipped: string[], failed: string[], errors: string[] }>}
  */
 export async function triggerAutoWeeklySummaries(basePath = '.', options = {}) {
-  const { onProgress } = options;
-
-  const unsummarizedWeeks = await findUnsummarizedWeeks(basePath);
-
-  const result = {
-    generated: [],
-    skipped: [],
-    failed: [],
-    errors: [],
-  };
-
-  for (const weekStr of unsummarizedWeeks) {
+  return tracer.startActiveSpan('commit_story.commands.trigger_auto_weekly_summaries', async (span) => {
     try {
-      const summaryResult = await generateAndSaveWeeklySummary(weekStr, basePath);
+      const { onProgress } = options;
 
-      if (summaryResult.saved) {
-        result.generated.push(summaryResult.path);
-        if (onProgress) {
-          onProgress(`Generated weekly summary for ${weekStr}`);
-        }
+      const unsummarizedWeeks = await findUnsummarizedWeeks(basePath);
+      span.setAttribute('commit_story.journal.unsummarized_weeks_count', unsummarizedWeeks.length);
 
-        if (summaryResult.errors && summaryResult.errors.length > 0) {
-          for (const err of summaryResult.errors) {
-            result.errors.push(`${weekStr}: ${err}`);
+      const result = {
+        generated: [],
+        skipped: [],
+        failed: [],
+        errors: [],
+      };
+
+      for (const weekStr of unsummarizedWeeks) {
+        try {
+          const summaryResult = await generateAndSaveWeeklySummary(weekStr, basePath);
+
+          if (summaryResult.saved) {
+            result.generated.push(summaryResult.path);
+            if (onProgress) {
+              onProgress(`Generated weekly summary for ${weekStr}`);
+            }
+
+            if (summaryResult.errors && summaryResult.errors.length > 0) {
+              for (const err of summaryResult.errors) {
+                result.errors.push(`${weekStr}: ${err}`);
+              }
+            }
+          } else {
+            result.skipped.push(weekStr);
+          }
+        } catch (err) {
+          result.failed.push(weekStr);
+          result.errors.push(`${weekStr}: ${getErrorMessage(err)}`);
+          if (onProgress) {
+            onProgress(`Failed to generate weekly summary for ${weekStr}: ${getErrorMessage(err)}`);
           }
         }
-      } else {
-        result.skipped.push(weekStr);
       }
-    } catch (err) {
-      result.failed.push(weekStr);
-      result.errors.push(`${weekStr}: ${getErrorMessage(err)}`);
-      if (onProgress) {
-        onProgress(`Failed to generate weekly summary for ${weekStr}: ${getErrorMessage(err)}`);
-      }
-    }
-  }
 
-  return result;
+      span.setAttribute('commit_story.journal.summaries_count', result.generated.length);
+      return result;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -145,43 +173,55 @@ export async function triggerAutoWeeklySummaries(basePath = '.', options = {}) {
  * @returns {Promise<{ generated: string[], skipped: string[], failed: string[], errors: string[] }>}
  */
 export async function triggerAutoMonthlySummaries(basePath = '.', options = {}) {
-  const { onProgress } = options;
-
-  const unsummarizedMonths = await findUnsummarizedMonths(basePath);
-
-  const result = {
-    generated: [],
-    skipped: [],
-    failed: [],
-    errors: [],
-  };
-
-  for (const monthStr of unsummarizedMonths) {
+  return tracer.startActiveSpan('commit_story.commands.trigger_auto_monthly_summaries', async (span) => {
     try {
-      const summaryResult = await generateAndSaveMonthlySummary(monthStr, basePath);
+      const { onProgress } = options;
 
-      if (summaryResult.saved) {
-        result.generated.push(summaryResult.path);
-        if (onProgress) {
-          onProgress(`Generated monthly summary for ${monthStr}`);
-        }
+      const unsummarizedMonths = await findUnsummarizedMonths(basePath);
+      span.setAttribute('commit_story.journal.unsummarized_months_count', unsummarizedMonths.length);
 
-        if (summaryResult.errors && summaryResult.errors.length > 0) {
-          for (const err of summaryResult.errors) {
-            result.errors.push(`${monthStr}: ${err}`);
+      const result = {
+        generated: [],
+        skipped: [],
+        failed: [],
+        errors: [],
+      };
+
+      for (const monthStr of unsummarizedMonths) {
+        try {
+          const summaryResult = await generateAndSaveMonthlySummary(monthStr, basePath);
+
+          if (summaryResult.saved) {
+            result.generated.push(summaryResult.path);
+            if (onProgress) {
+              onProgress(`Generated monthly summary for ${monthStr}`);
+            }
+
+            if (summaryResult.errors && summaryResult.errors.length > 0) {
+              for (const err of summaryResult.errors) {
+                result.errors.push(`${monthStr}: ${err}`);
+              }
+            }
+          } else {
+            result.skipped.push(monthStr);
+          }
+        } catch (err) {
+          result.failed.push(monthStr);
+          result.errors.push(`${monthStr}: ${getErrorMessage(err)}`);
+          if (onProgress) {
+            onProgress(`Failed to generate monthly summary for ${monthStr}: ${getErrorMessage(err)}`);
           }
         }
-      } else {
-        result.skipped.push(monthStr);
       }
-    } catch (err) {
-      result.failed.push(monthStr);
-      result.errors.push(`${monthStr}: ${getErrorMessage(err)}`);
-      if (onProgress) {
-        onProgress(`Failed to generate monthly summary for ${monthStr}: ${getErrorMessage(err)}`);
-      }
-    }
-  }
 
-  return result;
+      span.setAttribute('commit_story.journal.summaries_count', result.generated.length);
+      return result;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }

--- a/src/managers/journal-manager.instrumentation.md
+++ b/src/managers/journal-manager.instrumentation.md
@@ -1,0 +1,30 @@
+# Instrumentation Report: src/managers/journal-manager.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 2
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 5.1K
+- **Output tokens**: 12.1K
+- **Cached tokens**: 25.0K
+
+## Schema Extensions
+- `span.commit_story.journal.save_entry`
+- `span.commit_story.journal.discover_reflections`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- formatTimestamp and formatJournalEntry are exported but are pure synchronous functions with no I/O — skipped per RST-001 (no spans on synchronous utilities regardless of export status).
+- extractFilesFromDiff, countDiffLines, formatReflectionsSection, parseReflectionEntry, parseTimeString, parseReflectionsFile, isInTimeWindow, and getYearMonthRange are all unexported synchronous helpers — skipped per RST-001 and RST-004.
+- The inner try/catch in saveJournalEntry (file-not-found check) has an empty catch body — it is a graceful-degradation catch representing expected control flow (file does not yet exist). No recordException or setStatus(ERROR) was added to it per NDS-007.
+- Both inner try/catch blocks in discoverReflections (readdir and readFile failures) have empty catch bodies that continue loop iteration — these represent expected conditions (directories or files that don't exist). No error recording was added per NDS-007.
+- commit_story.journal.file_path is a raw filesystem path. basename from node:path is not in the existing import destructure list, and adding new non-OTel imports is prohibited — raw path value is used as a known limitation (CDQ-007).
+- All attributes used (commit_story.commit.timestamp, commit_story.journal.file_path, commit_story.context.time_window_start, commit_story.context.time_window_end, commit_story.journal.quotes_count) are already registered in the schema — no new attribute keys were invented.
+- span.commit_story.journal.save_entry is a new span name not present in the schema. No existing schema span matches the saveJournalEntry operation (writing a formatted entry to disk) — the closest registered span is commit_story.journal.ensure_directory which only covers directory creation, a sub-operation already instrumented in the callee.
+- span.commit_story.journal.discover_reflections is a new span name not present in the schema. No existing schema span matches the discoverReflections operation (scanning reflection files across year-month directories and filtering by time window).
+
+## Advisory Findings
+- CDQ-007 (Attribute Data Quality):187: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):413: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.

--- a/src/managers/journal-manager.js
+++ b/src/managers/journal-manager.js
@@ -5,6 +5,7 @@
  * Uses fs/promises for async file operations and UTC-first time handling.
  */
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { readFile, appendFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
@@ -14,6 +15,8 @@ import {
   parseDateFromFilename,
   getYearMonth,
 } from '../utils/journal-paths.js';
+
+const tracer = trace.getTracer('commit-story');
 
 /** Separator between journal entries */
 const ENTRY_SEPARATOR = '\n═══════════════════════════════════════\n\n';
@@ -175,48 +178,61 @@ export function formatJournalEntry(sections, commit, reflections = []) {
  * @returns {Promise<string>} Path to saved file
  */
 export async function saveJournalEntry(sections, commit, reflections = [], basePath = '.', options = {}) {
-  const log = options.debug || (() => {});
-  const entryPath = getJournalEntryPath(commit.timestamp, basePath);
+  return tracer.startActiveSpan('commit_story.journal.save_entry', async (span) => {
+    try {
+      const log = options.debug || (() => {});
+      const entryPath = getJournalEntryPath(commit.timestamp, basePath);
 
-  // Ensure directory exists
-  await ensureDirectory(entryPath);
+      span.setAttribute('commit_story.commit.timestamp', commit.timestamp.toISOString());
+      span.setAttribute('commit_story.journal.file_path', entryPath);
 
-  // Check for duplicate entry
-  try {
-    const existing = await readFile(entryPath, 'utf-8');
+      // Ensure directory exists
+      await ensureDirectory(entryPath);
 
-    // Path 1: Exact hash match (catches re-runs of the same commit)
-    if (existing.includes(`Commit: ${commit.shortHash}`)) {
-      log(`Skipping duplicate entry: exact hash match (${commit.shortHash})`);
+      // Check for duplicate entry
+      try {
+        const existing = await readFile(entryPath, 'utf-8');
+
+        // Path 1: Exact hash match (catches re-runs of the same commit)
+        if (existing.includes(`Commit: ${commit.shortHash}`)) {
+          log(`Skipping duplicate entry: exact hash match (${commit.shortHash})`);
+          return entryPath;
+        }
+
+        // Path 2: Semantic match (catches cherry-pick/rebase duplicates)
+        // Cherry-picks and rebases preserve author timestamp and commit message
+        // but produce a new commit hash. Match on both to avoid false positives.
+        // Split into entry blocks so we check timestamp+message within the SAME entry,
+        // avoiding false positives when different entries share one field each.
+        const timeStr = formatTimestamp(commit.timestamp);
+        const commitMessage = (commit.message || '').split('\n')[0];
+        const entryBlocks = existing.split('═══════════════════════════════════════');
+        const isSemanticDup = commitMessage && entryBlocks.some(
+          block => block.includes(`## ${timeStr}`) && block.includes(`**Message**: "${commitMessage}"`)
+        );
+        if (isSemanticDup) {
+          log(`Skipping duplicate entry: semantic match — same timestamp (${timeStr}) and message ("${commitMessage}"), likely cherry-pick/rebase of ${commit.shortHash}`);
+          return entryPath;
+        }
+      } catch {
+        // File doesn't exist yet, proceed
+      }
+
+      // Format the entry
+      const formattedEntry = formatJournalEntry(sections, commit, reflections);
+
+      // Append to file (creates if doesn't exist)
+      await appendFile(entryPath, formattedEntry + '\n', 'utf-8');
+
       return entryPath;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-
-    // Path 2: Semantic match (catches cherry-pick/rebase duplicates)
-    // Cherry-picks and rebases preserve author timestamp and commit message
-    // but produce a new commit hash. Match on both to avoid false positives.
-    // Split into entry blocks so we check timestamp+message within the SAME entry,
-    // avoiding false positives when different entries share one field each.
-    const timeStr = formatTimestamp(commit.timestamp);
-    const commitMessage = (commit.message || '').split('\n')[0];
-    const entryBlocks = existing.split('═══════════════════════════════════════');
-    const isSemanticDup = commitMessage && entryBlocks.some(
-      block => block.includes(`## ${timeStr}`) && block.includes(`**Message**: "${commitMessage}"`)
-    );
-    if (isSemanticDup) {
-      log(`Skipping duplicate entry: semantic match — same timestamp (${timeStr}) and message ("${commitMessage}"), likely cherry-pick/rebase of ${commit.shortHash}`);
-      return entryPath;
-    }
-  } catch {
-    // File doesn't exist yet, proceed
-  }
-
-  // Format the entry
-  const formattedEntry = formatJournalEntry(sections, commit, reflections);
-
-  // Append to file (creates if doesn't exist)
-  await appendFile(entryPath, formattedEntry + '\n', 'utf-8');
-
-  return entryPath;
+  });
 }
 
 /**
@@ -325,71 +341,85 @@ function isInTimeWindow(timestamp, startTime, endTime) {
  * @returns {Promise<Array>} Array of reflections sorted chronologically
  */
 export async function discoverReflections(startTime, endTime, basePath = '.') {
-  const reflections = [];
-
-  // Get all year-month directories that could contain relevant reflections
-  const startYearMonth = getYearMonth(startTime);
-  const endYearMonth = getYearMonth(endTime);
-  const yearMonths = getYearMonthRange(startYearMonth, endYearMonth);
-
-  for (const yearMonth of yearMonths) {
-    const reflectionsDir = join(basePath, 'journal', 'reflections', yearMonth);
-
+  return tracer.startActiveSpan('commit_story.journal.discover_reflections', async (span) => {
     try {
-      const files = await readdir(reflectionsDir);
+      span.setAttribute('commit_story.context.time_window_start', startTime.toISOString());
+      span.setAttribute('commit_story.context.time_window_end', endTime.toISOString());
 
-      for (const file of files) {
-        if (!file.endsWith('.md')) {
-          continue;
-        }
+      const reflections = [];
 
-        const fileDate = parseDateFromFilename(file);
-        if (!fileDate) {
-          continue;
-        }
+      // Get all year-month directories that could contain relevant reflections
+      const startYearMonth = getYearMonth(startTime);
+      const endYearMonth = getYearMonth(endTime);
+      const yearMonths = getYearMonthRange(startYearMonth, endYearMonth);
 
-        // Quick check: skip files outside the date range
-        // (dates are at start of day, so include if within range)
-        const fileDateEnd = new Date(fileDate);
-        fileDateEnd.setHours(23, 59, 59, 999);
+      for (const yearMonth of yearMonths) {
+        const reflectionsDir = join(basePath, 'journal', 'reflections', yearMonth);
 
-        if (fileDateEnd.getTime() < startTime.getTime()) {
-          continue;
-        }
-        if (fileDate.getTime() > endTime.getTime()) {
-          continue;
-        }
-
-        // Read and parse reflections from file
-        const filePath = join(reflectionsDir, file);
         try {
-          const content = await readFile(filePath, 'utf-8');
-          const fileReflections = parseReflectionsFile(content, fileDate);
+          const files = await readdir(reflectionsDir);
 
-          // Filter to time window
-          for (const reflection of fileReflections) {
-            if (isInTimeWindow(reflection.timestamp, startTime, endTime)) {
-              reflections.push({
-                ...reflection,
-                filePath,
-              });
+          for (const file of files) {
+            if (!file.endsWith('.md')) {
+              continue;
+            }
+
+            const fileDate = parseDateFromFilename(file);
+            if (!fileDate) {
+              continue;
+            }
+
+            // Quick check: skip files outside the date range
+            // (dates are at start of day, so include if within range)
+            const fileDateEnd = new Date(fileDate);
+            fileDateEnd.setHours(23, 59, 59, 999);
+
+            if (fileDateEnd.getTime() < startTime.getTime()) {
+              continue;
+            }
+            if (fileDate.getTime() > endTime.getTime()) {
+              continue;
+            }
+
+            // Read and parse reflections from file
+            const filePath = join(reflectionsDir, file);
+            try {
+              const content = await readFile(filePath, 'utf-8');
+              const fileReflections = parseReflectionsFile(content, fileDate);
+
+              // Filter to time window
+              for (const reflection of fileReflections) {
+                if (isInTimeWindow(reflection.timestamp, startTime, endTime)) {
+                  reflections.push({
+                    ...reflection,
+                    filePath,
+                  });
+                }
+              }
+            } catch {
+              // Skip files that can't be read
+              continue;
             }
           }
         } catch {
-          // Skip files that can't be read
+          // Directory doesn't exist, skip
           continue;
         }
       }
-    } catch {
-      // Directory doesn't exist, skip
-      continue;
+
+      // Sort chronologically
+      reflections.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+      span.setAttribute('commit_story.journal.quotes_count', reflections.length);
+      return reflections;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  // Sort chronologically
-  reflections.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
-
-  return reflections;
+  });
 }
 
 

--- a/src/managers/summary-manager.instrumentation.md
+++ b/src/managers/summary-manager.instrumentation.md
@@ -1,0 +1,55 @@
+# Instrumentation Report: src/managers/summary-manager.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 9
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 9.3K
+- **Output tokens**: 32.6K
+- **Cached tokens**: 25.2K
+
+## Schema Extensions
+- `span.commit_story.journal.read_day_entries`
+- `span.commit_story.journal.save_daily_summary`
+- `span.commit_story.journal.generate_and_save_daily_summary`
+- `span.commit_story.journal.read_week_daily_summaries`
+- `span.commit_story.journal.save_weekly_summary`
+- `span.commit_story.journal.generate_and_save_weekly_summary`
+- `span.commit_story.journal.read_month_weekly_summaries`
+- `span.commit_story.journal.save_monthly_summary`
+- `span.commit_story.journal.generate_and_save_monthly_summary`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- formatDailySummary, formatWeeklySummary, and formatMonthlySummary are pure synchronous formatters with no I/O — they build a string from input parameters and return it. Skipped per RST-001 (no spans on synchronous utilities with no I/O).
+- getWeekBoundaries and getMonthBoundaries are pure synchronous date-arithmetic utilities with no I/O — they parse a string and compute Date values. Skipped per RST-001.
+- All inner catch blocks in the instrumented functions (access check for duplicate detection, readFile for missing daily summaries, readdir for missing directories, per-file readFile for unreadable files) are graceful expected-condition catches that return default values without rethrowing. No recordException or setStatus(ERROR) was added to them per NDS-007 — these represent normal control flow, not errors. The outer span-level catch handles any unexpected propagated errors.
+- All attributes used (commit_story.journal.entry_date, commit_story.journal.entries_count, commit_story.journal.file_path, commit_story.journal.week_label, commit_story.journal.summaries_count, commit_story.journal.month_label) are already registered in the schema. No new attribute keys were invented; attributesCreated is 0.
+- Nine new span names were created because no schema-defined span IDs matched these specific orchestration operations. The pre-existing schema spans for this namespace cover the generator graph nodes (generate_daily_summary, etc.) and utility operations (ensure_directory, save_entry), but not the pipeline read/save/orchestrate operations in this file.
+- commit_story.journal.file_path is set only on the successful-save path (not when returning null for duplicate detection). The input context is captured via entry_date/week_label/month_label which are set unconditionally at span open, satisfying COV-005 on all execution paths.
+- The raw summaryPath filesystem value is used for commit_story.journal.file_path. The node:path basename utility is already imported (join is imported but not basename), so CDQ-007 path shortening cannot be applied without adding a new non-OTel import. Noted as a known limitation — the full path is stored.
+
+## Advisory Findings
+- CDQ-007 (Attribute Data Quality):51: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):119: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):161: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):176: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):263: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):332: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):374: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):389: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):483: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):555: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):597: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):612: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

--- a/src/managers/summary-manager.js
+++ b/src/managers/summary-manager.js
@@ -1,6 +1,7 @@
 // ABOUTME: Orchestrates daily, weekly, and monthly summary generation — reads source content, calls graph, writes output
 // ABOUTME: Handles duplicate detection via file existence (DD-003) and force-regeneration
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { readFile, writeFile, access, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { generateDailySummary, generateWeeklySummary, generateMonthlySummary } from '../generators/summary-graph.js';
@@ -15,6 +16,7 @@ import {
 
 /** Separator between journal entries (matches journal-manager.js) */
 const ENTRY_SEPARATOR = '═══════════════════════════════════════';
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Read all journal entries for a given date.
@@ -24,26 +26,38 @@ const ENTRY_SEPARATOR = '══════════════════�
  * @returns {Promise<string[]>} Array of individual entry strings
  */
 export async function readDayEntries(date, basePath = '.') {
-  const entryPath = getJournalEntryPath(date, basePath);
+  return tracer.startActiveSpan('commit_story.journal.read_day_entries', async (span) => {
+    try {
+      span.setAttribute('commit_story.journal.entry_date', getDateString(date));
+      const entryPath = getJournalEntryPath(date, basePath);
 
-  let content;
-  try {
-    content = await readFile(entryPath, 'utf-8');
-  } catch {
-    return [];
-  }
+      let content;
+      try {
+        content = await readFile(entryPath, 'utf-8');
+      } catch {
+        return [];
+      }
 
-  if (!content || !content.trim()) {
-    return [];
-  }
+      if (!content || !content.trim()) {
+        return [];
+      }
 
-  // Split by separator, filter out empty parts
-  const entries = content
-    .split(ENTRY_SEPARATOR)
-    .map(e => e.trim())
-    .filter(e => e.length > 0);
+      // Split by separator, filter out empty parts
+      const entries = content
+        .split(ENTRY_SEPARATOR)
+        .map(e => e.trim())
+        .filter(e => e.length > 0);
 
-  return entries;
+      span.setAttribute('commit_story.journal.entries_count', entries.length);
+      return entries;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -83,23 +97,35 @@ export function formatDailySummary(sections, dateStr) {
  * @returns {Promise<string|null>} Path to saved file, or null if skipped
  */
 export async function saveDailySummary(content, date, basePath = '.', options = {}) {
-  const summaryPath = getSummaryPath('daily', date, basePath);
-
-  // Check for existing summary (DD-003: file existence for duplicate detection)
-  if (!options.force) {
+  return tracer.startActiveSpan('commit_story.journal.save_daily_summary', async (span) => {
     try {
-      await access(summaryPath);
-      // File exists, skip
-      return null;
-    } catch {
-      // File doesn't exist, proceed
+      span.setAttribute('commit_story.journal.entry_date', getDateString(date));
+      const summaryPath = getSummaryPath('daily', date, basePath);
+
+      // Check for existing summary (DD-003: file existence for duplicate detection)
+      if (!options.force) {
+        try {
+          await access(summaryPath);
+          // File exists, skip
+          return null;
+        } catch {
+          // File doesn't exist, proceed
+        }
+      }
+
+      await ensureDirectory(summaryPath);
+      await writeFile(summaryPath, content, 'utf-8');
+
+      span.setAttribute('commit_story.journal.file_path', summaryPath);
+      return summaryPath;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  await ensureDirectory(summaryPath);
-  await writeFile(summaryPath, content, 'utf-8');
-
-  return summaryPath;
+  });
 }
 
 /**
@@ -110,44 +136,58 @@ export async function saveDailySummary(content, date, basePath = '.', options = 
  * @returns {Promise<{ saved: boolean, path?: string, reason?: string, entryCount?: number, errors?: string[] }>}
  */
 export async function generateAndSaveDailySummary(date, basePath = '.', options = {}) {
-  const dateStr = getDateString(date);
-
-  // Check for existing summary first (avoid reading entries unnecessarily)
-  if (!options.force) {
-    const summaryPath = getSummaryPath('daily', date, basePath);
+  return tracer.startActiveSpan('commit_story.journal.generate_and_save_daily_summary', async (span) => {
     try {
-      await access(summaryPath);
-      return { saved: false, reason: `Summary already exists for ${dateStr}` };
-    } catch {
-      // Doesn't exist, proceed
+      const dateStr = getDateString(date);
+      span.setAttribute('commit_story.journal.entry_date', dateStr);
+
+      // Check for existing summary first (avoid reading entries unnecessarily)
+      if (!options.force) {
+        const summaryPath = getSummaryPath('daily', date, basePath);
+        try {
+          await access(summaryPath);
+          return { saved: false, reason: `Summary already exists for ${dateStr}` };
+        } catch {
+          // Doesn't exist, proceed
+        }
+      }
+
+      // Read entries for the date
+      const entries = await readDayEntries(date, basePath);
+      if (entries.length === 0) {
+        return { saved: false, reason: `Skipped ${dateStr}: no entries found` };
+      }
+
+      span.setAttribute('commit_story.journal.entries_count', entries.length);
+
+      // Generate summary via LangGraph
+      const result = await generateDailySummary(entries, dateStr);
+
+      // Format the output
+      const formatted = formatDailySummary(result, dateStr);
+
+      // Save to file
+      const path = await saveDailySummary(formatted, date, basePath, options);
+
+      if (!path) {
+        return { saved: false, reason: `Summary already exists for ${dateStr}` };
+      }
+
+      span.setAttribute('commit_story.journal.file_path', path);
+      return {
+        saved: true,
+        path,
+        entryCount: entries.length,
+        errors: result.errors || [],
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  // Read entries for the date
-  const entries = await readDayEntries(date, basePath);
-  if (entries.length === 0) {
-    return { saved: false, reason: `Skipped ${dateStr}: no entries found` };
-  }
-
-  // Generate summary via LangGraph
-  const result = await generateDailySummary(entries, dateStr);
-
-  // Format the output
-  const formatted = formatDailySummary(result, dateStr);
-
-  // Save to file
-  const path = await saveDailySummary(formatted, date, basePath, options);
-
-  if (!path) {
-    return { saved: false, reason: `Summary already exists for ${dateStr}` };
-  }
-
-  return {
-    saved: true,
-    path,
-    entryCount: entries.length,
-    errors: result.errors || [],
-  };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -195,29 +235,41 @@ export function getWeekBoundaries(weekStr) {
  * @returns {Promise<Array<{ date: string, content: string }>>} Daily summaries sorted by date
  */
 export async function readWeekDailySummaries(weekStr, basePath = '.') {
-  const { monday, sunday } = getWeekBoundaries(weekStr);
-
-  const summaries = [];
-
-  // Check each day in the week
-  const current = new Date(monday);
-  while (current <= sunday) {
-    const dateStr = getDateString(current);
-    const dailyPath = getSummaryPath('daily', current, basePath);
-
+  return tracer.startActiveSpan('commit_story.journal.read_week_daily_summaries', async (span) => {
     try {
-      const content = await readFile(dailyPath, 'utf-8');
-      if (content && content.trim()) {
-        summaries.push({ date: dateStr, content: content.trim() });
+      span.setAttribute('commit_story.journal.week_label', weekStr);
+      const { monday, sunday } = getWeekBoundaries(weekStr);
+
+      const summaries = [];
+
+      // Check each day in the week
+      const current = new Date(monday);
+      while (current <= sunday) {
+        const dateStr = getDateString(current);
+        const dailyPath = getSummaryPath('daily', current, basePath);
+
+        try {
+          const content = await readFile(dailyPath, 'utf-8');
+          if (content && content.trim()) {
+            summaries.push({ date: dateStr, content: content.trim() });
+          }
+        } catch {
+          // No daily summary for this day — skip
+        }
+
+        current.setDate(current.getDate() + 1);
       }
-    } catch {
-      // No daily summary for this day — skip
+
+      span.setAttribute('commit_story.journal.summaries_count', summaries.length);
+      return summaries;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-
-    current.setDate(current.getDate() + 1);
-  }
-
-  return summaries;
+  });
 }
 
 /**
@@ -257,24 +309,36 @@ export function formatWeeklySummary(sections, weekStr) {
  * @returns {Promise<string|null>} Path to saved file, or null if skipped
  */
 export async function saveWeeklySummary(content, weekStr, basePath = '.', options = {}) {
-  // Use any date in the week to compute the path (Monday)
-  const { monday } = getWeekBoundaries(weekStr);
-  const summaryPath = getSummaryPath('weekly', monday, basePath);
-
-  // Check for existing summary (DD-003)
-  if (!options.force) {
+  return tracer.startActiveSpan('commit_story.journal.save_weekly_summary', async (span) => {
     try {
-      await access(summaryPath);
-      return null;
-    } catch {
-      // Doesn't exist, proceed
+      span.setAttribute('commit_story.journal.week_label', weekStr);
+      // Use any date in the week to compute the path (Monday)
+      const { monday } = getWeekBoundaries(weekStr);
+      const summaryPath = getSummaryPath('weekly', monday, basePath);
+
+      // Check for existing summary (DD-003)
+      if (!options.force) {
+        try {
+          await access(summaryPath);
+          return null;
+        } catch {
+          // Doesn't exist, proceed
+        }
+      }
+
+      await ensureDirectory(summaryPath);
+      await writeFile(summaryPath, content, 'utf-8');
+
+      span.setAttribute('commit_story.journal.file_path', summaryPath);
+      return summaryPath;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  await ensureDirectory(summaryPath);
-  await writeFile(summaryPath, content, 'utf-8');
-
-  return summaryPath;
+  });
 }
 
 /**
@@ -285,43 +349,58 @@ export async function saveWeeklySummary(content, weekStr, basePath = '.', option
  * @returns {Promise<{ saved: boolean, path?: string, reason?: string, dayCount?: number, errors?: string[] }>}
  */
 export async function generateAndSaveWeeklySummary(weekStr, basePath = '.', options = {}) {
-  // Check for existing summary first
-  if (!options.force) {
-    const { monday } = getWeekBoundaries(weekStr);
-    const summaryPath = getSummaryPath('weekly', monday, basePath);
+  return tracer.startActiveSpan('commit_story.journal.generate_and_save_weekly_summary', async (span) => {
     try {
-      await access(summaryPath);
-      return { saved: false, reason: `Weekly summary already exists for ${weekStr}` };
-    } catch {
-      // Doesn't exist, proceed
+      span.setAttribute('commit_story.journal.week_label', weekStr);
+
+      // Check for existing summary first
+      if (!options.force) {
+        const { monday } = getWeekBoundaries(weekStr);
+        const summaryPath = getSummaryPath('weekly', monday, basePath);
+        try {
+          await access(summaryPath);
+          return { saved: false, reason: `Weekly summary already exists for ${weekStr}` };
+        } catch {
+          // Doesn't exist, proceed
+        }
+      }
+
+      // Read daily summaries for the week
+      const dailySummaries = await readWeekDailySummaries(weekStr, basePath);
+      if (dailySummaries.length === 0) {
+        return { saved: false, reason: `Skipped ${weekStr}: no daily summaries found` };
+      }
+
+      span.setAttribute('commit_story.journal.summaries_count', dailySummaries.length);
+
+      // Generate weekly summary via LangGraph
+      const result = await generateWeeklySummary(dailySummaries, weekStr);
+
+      // Format the output
+      const formatted = formatWeeklySummary(result, weekStr);
+
+      // Save to file
+      const path = await saveWeeklySummary(formatted, weekStr, basePath, options);
+
+      if (!path) {
+        return { saved: false, reason: `Weekly summary already exists for ${weekStr}` };
+      }
+
+      span.setAttribute('commit_story.journal.file_path', path);
+      return {
+        saved: true,
+        path,
+        dayCount: dailySummaries.length,
+        errors: result.errors || [],
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  // Read daily summaries for the week
-  const dailySummaries = await readWeekDailySummaries(weekStr, basePath);
-  if (dailySummaries.length === 0) {
-    return { saved: false, reason: `Skipped ${weekStr}: no daily summaries found` };
-  }
-
-  // Generate weekly summary via LangGraph
-  const result = await generateWeeklySummary(dailySummaries, weekStr);
-
-  // Format the output
-  const formatted = formatWeeklySummary(result, weekStr);
-
-  // Save to file
-  const path = await saveWeeklySummary(formatted, weekStr, basePath, options);
-
-  if (!path) {
-    return { saved: false, reason: `Weekly summary already exists for ${weekStr}` };
-  }
-
-  return {
-    saved: true,
-    path,
-    dayCount: dailySummaries.length,
-    errors: result.errors || [],
-  };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -362,43 +441,55 @@ export function getMonthBoundaries(monthStr) {
  * @returns {Promise<Array<{ weekLabel: string, content: string }>>} Weekly summaries sorted by week
  */
 export async function readMonthWeeklySummaries(monthStr, basePath = '.') {
-  const { firstDay, lastDay } = getMonthBoundaries(monthStr);
-  const weeklyDir = getSummariesDirectory('weekly', basePath);
+  return tracer.startActiveSpan('commit_story.journal.read_month_weekly_summaries', async (span) => {
+    try {
+      span.setAttribute('commit_story.journal.month_label', monthStr);
+      const { firstDay, lastDay } = getMonthBoundaries(monthStr);
+      const weeklyDir = getSummariesDirectory('weekly', basePath);
 
-  let files;
-  try {
-    files = await readdir(weeklyDir);
-  } catch {
-    return [];
-  }
-
-  const weekPattern = /^(\d{4}-W\d{2})\.md$/;
-  const summaries = [];
-
-  for (const file of files.sort()) {
-    const match = file.match(weekPattern);
-    if (!match) continue;
-
-    const weekLabel = match[1];
-
-    // Check if this week overlaps with the month
-    // Import getWeekBoundaries locally to avoid circular dependency concerns
-    const { monday, sunday } = getWeekBoundaries(weekLabel);
-
-    // Week overlaps with month if week's Sunday >= month's first day AND week's Monday <= month's last day
-    if (sunday >= firstDay && monday <= lastDay) {
+      let files;
       try {
-        const content = await readFile(join(weeklyDir, file), 'utf-8');
-        if (content && content.trim()) {
-          summaries.push({ weekLabel, content: content.trim() });
-        }
+        files = await readdir(weeklyDir);
       } catch {
-        // Skip unreadable files
+        return [];
       }
-    }
-  }
 
-  return summaries;
+      const weekPattern = /^(\d{4}-W\d{2})\.md$/;
+      const summaries = [];
+
+      for (const file of files.sort()) {
+        const match = file.match(weekPattern);
+        if (!match) continue;
+
+        const weekLabel = match[1];
+
+        // Check if this week overlaps with the month
+        // Import getWeekBoundaries locally to avoid circular dependency concerns
+        const { monday, sunday } = getWeekBoundaries(weekLabel);
+
+        // Week overlaps with month if week's Sunday >= month's first day AND week's Monday <= month's last day
+        if (sunday >= firstDay && monday <= lastDay) {
+          try {
+            const content = await readFile(join(weeklyDir, file), 'utf-8');
+            if (content && content.trim()) {
+              summaries.push({ weekLabel, content: content.trim() });
+            }
+          } catch {
+            // Skip unreadable files
+          }
+        }
+      }
+
+      span.setAttribute('commit_story.journal.summaries_count', summaries.length);
+      return summaries;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -442,23 +533,35 @@ export function formatMonthlySummary(sections, monthStr) {
  * @returns {Promise<string|null>} Path to saved file, or null if skipped
  */
 export async function saveMonthlySummary(content, monthStr, basePath = '.', options = {}) {
-  const { firstDay } = getMonthBoundaries(monthStr);
-  const summaryPath = getSummaryPath('monthly', firstDay, basePath);
-
-  // Check for existing summary (DD-003)
-  if (!options.force) {
+  return tracer.startActiveSpan('commit_story.journal.save_monthly_summary', async (span) => {
     try {
-      await access(summaryPath);
-      return null;
-    } catch {
-      // Doesn't exist, proceed
+      span.setAttribute('commit_story.journal.month_label', monthStr);
+      const { firstDay } = getMonthBoundaries(monthStr);
+      const summaryPath = getSummaryPath('monthly', firstDay, basePath);
+
+      // Check for existing summary (DD-003)
+      if (!options.force) {
+        try {
+          await access(summaryPath);
+          return null;
+        } catch {
+          // Doesn't exist, proceed
+        }
+      }
+
+      await ensureDirectory(summaryPath);
+      await writeFile(summaryPath, content, 'utf-8');
+
+      span.setAttribute('commit_story.journal.file_path', summaryPath);
+      return summaryPath;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  await ensureDirectory(summaryPath);
-  await writeFile(summaryPath, content, 'utf-8');
-
-  return summaryPath;
+  });
 }
 
 /**
@@ -469,41 +572,56 @@ export async function saveMonthlySummary(content, monthStr, basePath = '.', opti
  * @returns {Promise<{ saved: boolean, path?: string, reason?: string, weekCount?: number, errors?: string[] }>}
  */
 export async function generateAndSaveMonthlySummary(monthStr, basePath = '.', options = {}) {
-  // Check for existing summary first
-  if (!options.force) {
-    const { firstDay } = getMonthBoundaries(monthStr);
-    const summaryPath = getSummaryPath('monthly', firstDay, basePath);
+  return tracer.startActiveSpan('commit_story.journal.generate_and_save_monthly_summary', async (span) => {
     try {
-      await access(summaryPath);
-      return { saved: false, reason: `Monthly summary already exists for ${monthStr}` };
-    } catch {
-      // Doesn't exist, proceed
+      span.setAttribute('commit_story.journal.month_label', monthStr);
+
+      // Check for existing summary first
+      if (!options.force) {
+        const { firstDay } = getMonthBoundaries(monthStr);
+        const summaryPath = getSummaryPath('monthly', firstDay, basePath);
+        try {
+          await access(summaryPath);
+          return { saved: false, reason: `Monthly summary already exists for ${monthStr}` };
+        } catch {
+          // Doesn't exist, proceed
+        }
+      }
+
+      // Read weekly summaries for the month
+      const weeklySummaries = await readMonthWeeklySummaries(monthStr, basePath);
+      if (weeklySummaries.length === 0) {
+        return { saved: false, reason: `Skipped ${monthStr}: no weekly summaries found` };
+      }
+
+      span.setAttribute('commit_story.journal.summaries_count', weeklySummaries.length);
+
+      // Generate monthly summary via LangGraph
+      const result = await generateMonthlySummary(weeklySummaries, monthStr);
+
+      // Format the output
+      const formatted = formatMonthlySummary(result, monthStr);
+
+      // Save to file
+      const path = await saveMonthlySummary(formatted, monthStr, basePath, options);
+
+      if (!path) {
+        return { saved: false, reason: `Monthly summary already exists for ${monthStr}` };
+      }
+
+      span.setAttribute('commit_story.journal.file_path', path);
+      return {
+        saved: true,
+        path,
+        weekCount: weeklySummaries.length,
+        errors: result.errors || [],
+      };
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-
-  // Read weekly summaries for the month
-  const weeklySummaries = await readMonthWeeklySummaries(monthStr, basePath);
-  if (weeklySummaries.length === 0) {
-    return { saved: false, reason: `Skipped ${monthStr}: no weekly summaries found` };
-  }
-
-  // Generate monthly summary via LangGraph
-  const result = await generateMonthlySummary(weeklySummaries, monthStr);
-
-  // Format the output
-  const formatted = formatMonthlySummary(result, monthStr);
-
-  // Save to file
-  const path = await saveMonthlySummary(formatted, monthStr, basePath, options);
-
-  if (!path) {
-    return { saved: false, reason: `Monthly summary already exists for ${monthStr}` };
-  }
-
-  return {
-    saved: true,
-    path,
-    weekCount: weeklySummaries.length,
-    errors: result.errors || [],
-  };
+  });
 }

--- a/src/mcp/server.instrumentation.md
+++ b/src/mcp/server.instrumentation.md
@@ -1,0 +1,24 @@
+# Instrumentation Report: src/mcp/server.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 1
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 1.1K
+- **Output tokens**: 2.5K
+- **Cached tokens**: 24.6K
+
+## Schema Extensions
+- `span.commit_story.mcp.main`
+- `commit_story.mcp.transport_type`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- createServer is a synchronous unexported function with no I/O that simply constructs an object and registers tools — it does not need a span (RST-001: no spans on synchronous non-I/O utilities; RST-004: unexported with an exported orchestrator covering its execution path).
+- main() is the COV-001 async entry point. process.exit(1) appears only in the .catch() callback at the call site outside main()'s own body, so RST-006 does not apply and main() is safely spanned.
+- New span name 'commit_story.mcp.main' declared as a schema extension — no existing registry span matches this MCP server startup operation.
+- New attribute 'commit_story.mcp.transport_type' captures the transport mechanism ('stdio') used by the MCP server. No registered attribute key in the schema covers transport type for MCP server connections — the closest registered attributes are context source types, which are semantically distinct from server transport configuration.
+- @modelcontextprotocol/sdk is in the auto-instrumentation allowlist (MCPInstrumentation) — recorded in librariesNeeded. Manual span on main() is still added as the COV-001 entry point; MCP tool calls become child spans via auto-instrumentation.
+- pino is in the auto-instrumentation allowlist (@opentelemetry/instrumentation-pino) — recorded in librariesNeeded.

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -22,6 +22,7 @@
  *   }
  */
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { registerReflectionTool } from './tools/reflection-tool.js';
@@ -30,6 +31,7 @@ import pino from 'pino';
 
 // stdout is reserved for JSON-RPC — logger must write to stderr
 const logger = pino({ level: 'info' }, process.stderr);
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Create and configure the MCP server
@@ -52,12 +54,23 @@ function createServer() {
  * Main entry point
  */
 async function main() {
-  const server = createServer();
-  const transport = new StdioServerTransport();
+  return tracer.startActiveSpan('commit_story.mcp.main', async (span) => {
+    try {
+      span.setAttribute('commit_story.mcp.transport_type', 'stdio');
+      const server = createServer();
+      const transport = new StdioServerTransport();
 
-  await server.connect(transport);
+      await server.connect(transport);
 
-  logger.info('Commit Story MCP Server running on stdio');
+      logger.info('Commit Story MCP Server running on stdio');
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 // Run the server

--- a/src/mcp/tools/context-capture-tool.instrumentation.md
+++ b/src/mcp/tools/context-capture-tool.instrumentation.md
@@ -1,0 +1,28 @@
+# Instrumentation Report: src/mcp/tools/context-capture-tool.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 1
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 1.4K
+- **Output tokens**: 4.7K
+
+## Schema Extensions
+- `span.commit_story.context.save_context`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- saveContext is an unexported async function that performs filesystem I/O (mkdir + appendFile). No exported orchestrator wraps it, so RST-004 does not exempt it — it is the effective entry point for context persistence and receives a COV-004 span (commit_story.context.save_context).
+- getContextPath, formatTimestamp, and formatContextEntry are all pure synchronous helpers with no I/O — they are skipped per RST-001.
+- registerContextCaptureTool is a synchronous exported function that registers a tool handler — it is skipped per RST-001. The anonymous async callback it registers is not exported and delegates entirely to saveContext, which is now instrumented, so no separate span is needed for the callback.
+- The anonymous async callback's catch block returns content without rethrowing — this is a graceful degradation path (NDS-007). No recordException or setStatus was added to that catch.
+- commit_story.journal.entry_date and commit_story.journal.file_path are both registered schema attributes used on the saveContext span. No new attribute schema extensions were required.
+- The file path written to commit_story.journal.file_path is project-relative (starts with 'journal/context/...'), not an absolute filesystem path, so no CDQ-007 basename transformation is needed.
+- span.commit_story.context.save_context is a new span name not present in the schema registry. It follows the commit_story namespace and context category consistent with existing registered spans. No existing schema span matched the 'save to filesystem' operation semantically.
+
+## Advisory Findings
+- CDQ-006 (isRecording Guard):77: CDQ-006 (isRecording Guard) fired because span.setAttribute() is called with an expensive computation (map, reduce, filter, JSON.stringify, etc.) or an external source string (value fetched from git output, an API response, file contents, or any source whose length is unbounded) and no span.isRecording() guard. When sampling drops the span, that work still runs on every request. Wrap the call in `if (span.isRecording()) { ... }` to skip it when the span won't be exported. Skip this finding for root spans at entry points — the guard adds clutter for negligible gain there.
+- CDQ-007 (Attribute Data Quality):86: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

--- a/src/mcp/tools/context-capture-tool.js
+++ b/src/mcp/tools/context-capture-tool.js
@@ -9,9 +9,12 @@
  * - Comprehensive context: When user just says "capture context"
  */
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { z } from 'zod';
 import { mkdir, appendFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+
+const tracer = trace.getTracer('commit-story');
 
 /** Separator bar for entries */
 const SEPARATOR = '═══════════════════════════════════════';
@@ -67,17 +70,29 @@ ${SEPARATOR}
  * @returns {Promise<string>} - The path where the context was saved
  */
 async function saveContext(text) {
-  const now = new Date();
-  const filePath = getContextPath(now);
+  return tracer.startActiveSpan('commit_story.context.save_context', async (span) => {
+    try {
+      const now = new Date();
+      const filePath = getContextPath(now);
+      span.setAttribute('commit_story.journal.entry_date', now.toISOString().split('T')[0]);
 
-  // Ensure directory exists
-  await mkdir(dirname(filePath), { recursive: true });
+      // Ensure directory exists
+      await mkdir(dirname(filePath), { recursive: true });
 
-  // Format and append the entry
-  const entry = formatContextEntry(text, now);
-  await appendFile(filePath, entry, 'utf-8');
+      // Format and append the entry
+      const entry = formatContextEntry(text, now);
+      await appendFile(filePath, entry, 'utf-8');
 
-  return filePath;
+      span.setAttribute('commit_story.journal.file_path', filePath);
+      return filePath;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**

--- a/src/mcp/tools/reflection-tool.instrumentation.md
+++ b/src/mcp/tools/reflection-tool.instrumentation.md
@@ -1,0 +1,18 @@
+# Instrumentation Report: src/mcp/tools/reflection-tool.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 2 (multi-turn-fix)
+- **Input tokens**: 1.4K
+- **Output tokens**: 3.3K
+
+## Validation Journey
+1. **Attempt 1**: 5 blocking errors (NDS-003 (Code Preserved):5)
+2. **Attempt 2**: 0 errors
+
+## Notes
+- All exported functions are synchronous (registerReflectionTool) — no async I/O to trace. No LLM call made.
+
+## Advisory Findings
+- COV-004 (Async Operation Spans):65: COV-004 (Async Operation Spans) fired because this async function doesn't have a span. Without one, traces have a gap here — callers can see time was spent and whether an error occurred, but not what happened inside this function. Add a span unless this is a pure synchronous utility with no I/O (RST-001 exemption) — context propagation covers unexported internal helpers.

--- a/src/traceloop-init.instrumentation.md
+++ b/src/traceloop-init.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/traceloop-init.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/utils/commit-analyzer.instrumentation.md
+++ b/src/utils/commit-analyzer.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/utils/commit-analyzer.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/utils/config.instrumentation.md
+++ b/src/utils/config.instrumentation.md
@@ -1,0 +1,14 @@
+# Instrumentation Report: src/utils/config.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 0
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 0.0K
+- **Output tokens**: 0.0K
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- Pre-scan: no instrumentable functions — all are pure sync utilities or unexported helpers. No LLM call made.

--- a/src/utils/journal-paths.instrumentation.md
+++ b/src/utils/journal-paths.instrumentation.md
@@ -1,0 +1,23 @@
+# Instrumentation Report: src/utils/journal-paths.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 1
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 2.8K
+- **Output tokens**: 5.3K
+- **Cached tokens**: 24.8K
+
+## Schema Extensions
+- `span.commit_story.journal.ensure_directory`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- getYearMonth, getDateString, getJournalEntryPath, getReflectionPath, getContextPath, getReflectionsDirectory, parseDateFromFilename, getJournalRoot, getISOWeekString, getSummaryPath, getSummariesDirectory are all pure synchronous functions with no I/O — skipped per RST-001 (no spans on synchronous utilities)
+- ensureDirectory is the sole exported async function and the only COV-001 entry point — instrumented with span name commit_story.journal.ensure_directory. The registered attribute commit_story.journal.file_path was used to capture the input filePath parameter before any branching.
+- span.commit_story.journal.ensure_directory is a new span name not present in the registry — declared in schemaExtensions. No existing schema span matched this filesystem directory-creation operation.
+
+## Advisory Findings
+- CDQ-007 (Attribute Data Quality):94: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.

--- a/src/utils/journal-paths.js
+++ b/src/utils/journal-paths.js
@@ -1,6 +1,7 @@
 // ABOUTME: Centralizes path generation for all journal files (entries, reflections, context, summaries)
 // ABOUTME: Uses date-based directory structure: journal/{type}/YYYY-MM/YYYY-MM-DD.md
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { mkdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 
@@ -9,6 +10,8 @@ const JOURNAL_ROOT = 'journal';
 
 /** Valid summary cadences */
 const VALID_CADENCES = ['daily', 'weekly', 'monthly'];
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Get YYYY-MM format for directory names
@@ -86,8 +89,19 @@ export function getReflectionsDirectory(date, basePath = '.') {
  * @param {string} filePath - Path to file
  */
 export async function ensureDirectory(filePath) {
-  const dir = dirname(filePath);
-  await mkdir(dir, { recursive: true });
+  return tracer.startActiveSpan('commit_story.journal.ensure_directory', async (span) => {
+    try {
+      span.setAttribute('commit_story.journal.file_path', filePath);
+      const dir = dirname(filePath);
+      await mkdir(dir, { recursive: true });
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**

--- a/src/utils/summary-detector.instrumentation.md
+++ b/src/utils/summary-detector.instrumentation.md
@@ -1,0 +1,56 @@
+# Instrumentation Report: src/utils/summary-detector.js
+
+## Summary
+- **Status**: success
+- **Spans added**: 9
+- **Attempts**: 1 (initial-generation)
+- **Input tokens**: 4.5K
+- **Output tokens**: 13.7K
+
+## Schema Extensions
+- `span.commit_story.journal.get_days_with_entries`
+- `span.commit_story.journal.get_summarized_days`
+- `span.commit_story.journal.find_unsummarized_days`
+- `span.commit_story.journal.get_summarized_weeks`
+- `span.commit_story.journal.get_days_with_daily_summaries`
+- `span.commit_story.journal.find_unsummarized_weeks`
+- `span.commit_story.journal.get_summarized_months`
+- `span.commit_story.journal.get_weeks_with_weekly_summaries`
+- `span.commit_story.journal.find_unsummarized_months`
+- `commit_story.journal.unsummarized_days_count`
+- `commit_story.journal.unsummarized_weeks_count`
+- `commit_story.journal.unsummarized_months_count`
+
+## Validation Journey
+1. **Attempt 1**: 0 errors
+
+## Notes
+- getTodayString is a pure synchronous helper that formats a date — it performs no I/O and has no async operations, so no span is added (RST-001: no spans on synchronous utilities without I/O).
+- getNowDate is a pure synchronous helper that constructs a Date object — it performs no I/O and has no async operations, so no span is added (RST-001: no spans on synchronous utilities without I/O).
+- The inner try/catch blocks inside getDaysWithEntries, getSummarizedDays, getDaysWithDailySummaries, getSummarizedWeeks, getSummarizedMonths, and getWeeksWithWeeklySummaries all handle readdir failures by returning empty collections or continuing — these are graceful-degradation catches with no rethrow, so recordException and setStatus(ERROR) are not added to them (NDS-007: do not add error recording to expected-condition catches).
+- Used commit_story.journal.entries_count (registered) for the count of entry dates returned by getDaysWithEntries — this attribute captures the count of journal entry days found, which matches the function's output semantically.
+- Used commit_story.journal.summaries_count (registered) across getSummarizedDays, getDaysWithDailySummaries, getSummarizedWeeks, getSummarizedMonths, and getWeeksWithWeeklySummaries — its brief is the generic agent-discovered label which does not restrict to a single summary type, so it applies across daily, weekly, and monthly summary counts. The span name provides the necessary context to distinguish which summary type the count refers to.
+- Declared commit_story.journal.unsummarized_days_count as a new extension (int) for findUnsummarizedDays because no registered key captures 'count of days that have entries but no daily summary' — commit_story.journal.entries_count counts all entry days (including summarized ones), making it semantically incorrect here.
+- Declared commit_story.journal.unsummarized_weeks_count as a new extension (int) for findUnsummarizedWeeks — no registered key captures 'count of weeks that have daily summaries but no weekly summary'. commit_story.journal.summaries_count counts existing summaries found, not gaps remaining.
+- Declared commit_story.journal.unsummarized_months_count as a new extension (int) for findUnsummarizedMonths — no registered key captures 'count of months that have weekly summaries but no monthly summary' for the same reason as unsummarized_weeks_count.
+- For findUnsummarizedDays, the original return expression was return entryDays.filter(...) — a call expression — which was captured to const result using the return-value capture exception so that span.setAttribute could reference result.length before returning.
+- getSummarizedDays, getSummarizedWeeks, getSummarizedMonths, and getWeeksWithWeeklySummaries are unexported async functions that perform filesystem I/O and are not covered by any auto-instrumentation library. Since they are on execution paths not directly wrapped by an exported orchestrator span (they are called from within already-spanned exported functions but each performs meaningful independent I/O), they are instrumented as COV-004 targets for visibility into filesystem access latency at each tier.
+
+## Advisory Findings
+- CDQ-007 (Attribute Data Quality):94: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):130: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):167: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):203: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):240: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):290: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):326: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):363: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- CDQ-007 (Attribute Data Quality):425: CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
+- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

--- a/src/utils/summary-detector.js
+++ b/src/utils/summary-detector.js
@@ -1,9 +1,12 @@
 // ABOUTME: Detects journal days/weeks/months that have content but no summary
 // ABOUTME: Scans entries and summaries directories to find gaps for auto-trigger
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { getISOWeekString, getYearMonth } from './journal-paths.js';
+
+const tracer = trace.getTracer('commit-story');
 
 /**
  * Get the current date string in the configured timezone.
@@ -55,38 +58,49 @@ function getNowDate() {
  * @returns {Promise<string[]>} Sorted array of date strings (YYYY-MM-DD)
  */
 export async function getDaysWithEntries(basePath = '.') {
-  const entriesDir = join(basePath, 'journal', 'entries');
-  const datePattern = /^\d{4}-\d{2}-\d{2}\.md$/;
-
-  let monthDirs;
-  try {
-    monthDirs = await readdir(entriesDir);
-  } catch {
-    return [];
-  }
-
-  const dates = [];
-
-  for (const monthDir of monthDirs) {
-    // Only process YYYY-MM directories
-    if (!/^\d{4}-\d{2}$/.test(monthDir)) continue;
-
-    let files;
+  return tracer.startActiveSpan('commit_story.journal.get_days_with_entries', async (span) => {
     try {
-      files = await readdir(join(entriesDir, monthDir));
-    } catch {
-      continue;
-    }
+      const entriesDir = join(basePath, 'journal', 'entries');
+      const datePattern = /^\d{4}-\d{2}-\d{2}\.md$/;
 
-    for (const file of files) {
-      if (datePattern.test(file)) {
-        dates.push(file.replace('.md', ''));
+      let monthDirs;
+      try {
+        monthDirs = await readdir(entriesDir);
+      } catch {
+        return [];
       }
-    }
-  }
 
-  dates.sort();
-  return dates;
+      const dates = [];
+
+      for (const monthDir of monthDirs) {
+        // Only process YYYY-MM directories
+        if (!/^\d{4}-\d{2}$/.test(monthDir)) continue;
+
+        let files;
+        try {
+          files = await readdir(join(entriesDir, monthDir));
+        } catch {
+          continue;
+        }
+
+        for (const file of files) {
+          if (datePattern.test(file)) {
+            dates.push(file.replace('.md', ''));
+          }
+        }
+      }
+
+      dates.sort();
+      span.setAttribute('commit_story.journal.entries_count', dates.length);
+      return dates;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -95,23 +109,34 @@ export async function getDaysWithEntries(basePath = '.') {
  * @returns {Promise<Set<string>>} Set of date strings (YYYY-MM-DD)
  */
 async function getSummarizedDays(basePath = '.') {
-  const summariesDir = join(basePath, 'journal', 'summaries', 'daily');
-  const datePattern = /^\d{4}-\d{2}-\d{2}\.md$/;
+  return tracer.startActiveSpan('commit_story.journal.get_summarized_days', async (span) => {
+    try {
+      const summariesDir = join(basePath, 'journal', 'summaries', 'daily');
+      const datePattern = /^\d{4}-\d{2}-\d{2}\.md$/;
 
-  let files;
-  try {
-    files = await readdir(summariesDir);
-  } catch {
-    return new Set();
-  }
+      let files;
+      try {
+        files = await readdir(summariesDir);
+      } catch {
+        return new Set();
+      }
 
-  const dates = new Set();
-  for (const file of files) {
-    if (datePattern.test(file)) {
-      dates.add(file.replace('.md', ''));
+      const dates = new Set();
+      for (const file of files) {
+        if (datePattern.test(file)) {
+          dates.add(file.replace('.md', ''));
+        }
+      }
+      span.setAttribute('commit_story.journal.summaries_count', dates.size);
+      return dates;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-  return dates;
+  });
 }
 
 /**
@@ -122,20 +147,32 @@ async function getSummarizedDays(basePath = '.') {
  * @returns {Promise<string[]>} Sorted array of unsummarized date strings
  */
 export async function findUnsummarizedDays(basePath = '.', options = {}) {
-  const entryDays = await getDaysWithEntries(basePath);
-  if (entryDays.length === 0) return [];
+  return tracer.startActiveSpan('commit_story.journal.find_unsummarized_days', async (span) => {
+    try {
+      const entryDays = await getDaysWithEntries(basePath);
+      if (entryDays.length === 0) return [];
 
-  const summarizedDays = await getSummarizedDays(basePath);
-  const today = getTodayString();
+      const summarizedDays = await getSummarizedDays(basePath);
+      const today = getTodayString();
 
-  return entryDays.filter(dateStr => {
-    // Exclude today — not yet complete
-    if (dateStr >= today) return false;
-    // Exclude dates at or after the cutoff
-    if (options.before && dateStr >= options.before) return false;
-    // Exclude already summarized
-    if (summarizedDays.has(dateStr)) return false;
-    return true;
+      const result = entryDays.filter(dateStr => {
+        // Exclude today — not yet complete
+        if (dateStr >= today) return false;
+        // Exclude dates at or after the cutoff
+        if (options.before && dateStr >= options.before) return false;
+        // Exclude already summarized
+        if (summarizedDays.has(dateStr)) return false;
+        return true;
+      });
+      span.setAttribute('commit_story.journal.unsummarized_days_count', result.length);
+      return result;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
   });
 }
 
@@ -145,23 +182,34 @@ export async function findUnsummarizedDays(basePath = '.', options = {}) {
  * @returns {Promise<Set<string>>} Set of week strings (YYYY-Www)
  */
 async function getSummarizedWeeks(basePath = '.') {
-  const summariesDir = join(basePath, 'journal', 'summaries', 'weekly');
-  const weekPattern = /^\d{4}-W\d{2}\.md$/;
+  return tracer.startActiveSpan('commit_story.journal.get_summarized_weeks', async (span) => {
+    try {
+      const summariesDir = join(basePath, 'journal', 'summaries', 'weekly');
+      const weekPattern = /^\d{4}-W\d{2}\.md$/;
 
-  let files;
-  try {
-    files = await readdir(summariesDir);
-  } catch {
-    return new Set();
-  }
+      let files;
+      try {
+        files = await readdir(summariesDir);
+      } catch {
+        return new Set();
+      }
 
-  const weeks = new Set();
-  for (const file of files) {
-    if (weekPattern.test(file)) {
-      weeks.add(file.replace('.md', ''));
+      const weeks = new Set();
+      for (const file of files) {
+        if (weekPattern.test(file)) {
+          weeks.add(file.replace('.md', ''));
+        }
+      }
+      span.setAttribute('commit_story.journal.summaries_count', weeks.size);
+      return weeks;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-  return weeks;
+  });
 }
 
 /**
@@ -170,24 +218,35 @@ async function getSummarizedWeeks(basePath = '.') {
  * @returns {Promise<string[]>} Sorted array of date strings (YYYY-MM-DD)
  */
 export async function getDaysWithDailySummaries(basePath = '.') {
-  const summariesDir = join(basePath, 'journal', 'summaries', 'daily');
-  const datePattern = /^\d{4}-\d{2}-\d{2}\.md$/;
+  return tracer.startActiveSpan('commit_story.journal.get_days_with_daily_summaries', async (span) => {
+    try {
+      const summariesDir = join(basePath, 'journal', 'summaries', 'daily');
+      const datePattern = /^\d{4}-\d{2}-\d{2}\.md$/;
 
-  let files;
-  try {
-    files = await readdir(summariesDir);
-  } catch {
-    return [];
-  }
+      let files;
+      try {
+        files = await readdir(summariesDir);
+      } catch {
+        return [];
+      }
 
-  const dates = [];
-  for (const file of files) {
-    if (datePattern.test(file)) {
-      dates.push(file.replace('.md', ''));
+      const dates = [];
+      for (const file of files) {
+        if (datePattern.test(file)) {
+          dates.push(file.replace('.md', ''));
+        }
+      }
+      dates.sort();
+      span.setAttribute('commit_story.journal.summaries_count', dates.length);
+      return dates;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-  dates.sort();
-  return dates;
+  });
 }
 
 /**
@@ -198,35 +257,46 @@ export async function getDaysWithDailySummaries(basePath = '.') {
  * @returns {Promise<string[]>} Sorted array of unsummarized ISO week strings
  */
 export async function findUnsummarizedWeeks(basePath = '.') {
-  const dailySummaryDates = await getDaysWithDailySummaries(basePath);
-  if (dailySummaryDates.length === 0) return [];
+  return tracer.startActiveSpan('commit_story.journal.find_unsummarized_weeks', async (span) => {
+    try {
+      const dailySummaryDates = await getDaysWithDailySummaries(basePath);
+      if (dailySummaryDates.length === 0) return [];
 
-  // Group daily summary dates into ISO weeks
-  const weeksWithSummaries = new Set();
-  for (const dateStr of dailySummaryDates) {
-    const [year, month, day] = dateStr.split('-').map(Number);
-    const date = new Date(year, month - 1, day);
-    const weekStr = getISOWeekString(date);
-    weeksWithSummaries.add(weekStr);
-  }
+      // Group daily summary dates into ISO weeks
+      const weeksWithSummaries = new Set();
+      for (const dateStr of dailySummaryDates) {
+        const [year, month, day] = dateStr.split('-').map(Number);
+        const date = new Date(year, month - 1, day);
+        const weekStr = getISOWeekString(date);
+        weeksWithSummaries.add(weekStr);
+      }
 
-  // Get current week to exclude it (timezone-aware)
-  const currentWeek = getISOWeekString(getNowDate());
+      // Get current week to exclude it (timezone-aware)
+      const currentWeek = getISOWeekString(getNowDate());
 
-  // Check which weeks already have weekly summaries
-  const summarizedWeeks = await getSummarizedWeeks(basePath);
+      // Check which weeks already have weekly summaries
+      const summarizedWeeks = await getSummarizedWeeks(basePath);
 
-  const unsummarized = [];
-  for (const weekStr of weeksWithSummaries) {
-    // Exclude current week — not yet complete
-    if (weekStr >= currentWeek) continue;
-    // Exclude already summarized
-    if (summarizedWeeks.has(weekStr)) continue;
-    unsummarized.push(weekStr);
-  }
+      const unsummarized = [];
+      for (const weekStr of weeksWithSummaries) {
+        // Exclude current week — not yet complete
+        if (weekStr >= currentWeek) continue;
+        // Exclude already summarized
+        if (summarizedWeeks.has(weekStr)) continue;
+        unsummarized.push(weekStr);
+      }
 
-  unsummarized.sort();
-  return unsummarized;
+      unsummarized.sort();
+      span.setAttribute('commit_story.journal.unsummarized_weeks_count', unsummarized.length);
+      return unsummarized;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }
 
 /**
@@ -235,23 +305,34 @@ export async function findUnsummarizedWeeks(basePath = '.') {
  * @returns {Promise<Set<string>>} Set of month strings (YYYY-MM)
  */
 async function getSummarizedMonths(basePath = '.') {
-  const summariesDir = join(basePath, 'journal', 'summaries', 'monthly');
-  const monthPattern = /^\d{4}-\d{2}\.md$/;
+  return tracer.startActiveSpan('commit_story.journal.get_summarized_months', async (span) => {
+    try {
+      const summariesDir = join(basePath, 'journal', 'summaries', 'monthly');
+      const monthPattern = /^\d{4}-\d{2}\.md$/;
 
-  let files;
-  try {
-    files = await readdir(summariesDir);
-  } catch {
-    return new Set();
-  }
+      let files;
+      try {
+        files = await readdir(summariesDir);
+      } catch {
+        return new Set();
+      }
 
-  const months = new Set();
-  for (const file of files) {
-    if (monthPattern.test(file)) {
-      months.add(file.replace('.md', ''));
+      const months = new Set();
+      for (const file of files) {
+        if (monthPattern.test(file)) {
+          months.add(file.replace('.md', ''));
+        }
+      }
+      span.setAttribute('commit_story.journal.summaries_count', months.size);
+      return months;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-  return months;
+  });
 }
 
 /**
@@ -260,24 +341,35 @@ async function getSummarizedMonths(basePath = '.') {
  * @returns {Promise<string[]>} Sorted array of week strings (YYYY-Www)
  */
 async function getWeeksWithWeeklySummaries(basePath = '.') {
-  const summariesDir = join(basePath, 'journal', 'summaries', 'weekly');
-  const weekPattern = /^\d{4}-W\d{2}\.md$/;
+  return tracer.startActiveSpan('commit_story.journal.get_weeks_with_weekly_summaries', async (span) => {
+    try {
+      const summariesDir = join(basePath, 'journal', 'summaries', 'weekly');
+      const weekPattern = /^\d{4}-W\d{2}\.md$/;
 
-  let files;
-  try {
-    files = await readdir(summariesDir);
-  } catch {
-    return [];
-  }
+      let files;
+      try {
+        files = await readdir(summariesDir);
+      } catch {
+        return [];
+      }
 
-  const weeks = [];
-  for (const file of files) {
-    if (weekPattern.test(file)) {
-      weeks.push(file.replace('.md', ''));
+      const weeks = [];
+      for (const file of files) {
+        if (weekPattern.test(file)) {
+          weeks.push(file.replace('.md', ''));
+        }
+      }
+      weeks.sort();
+      span.setAttribute('commit_story.journal.summaries_count', weeks.length);
+      return weeks;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
     }
-  }
-  weeks.sort();
-  return weeks;
+  });
 }
 
 /**
@@ -288,45 +380,56 @@ async function getWeeksWithWeeklySummaries(basePath = '.') {
  * @returns {Promise<string[]>} Sorted array of unsummarized month strings (YYYY-MM)
  */
 export async function findUnsummarizedMonths(basePath = '.') {
-  const weekLabels = await getWeeksWithWeeklySummaries(basePath);
-  if (weekLabels.length === 0) return [];
+  return tracer.startActiveSpan('commit_story.journal.find_unsummarized_months', async (span) => {
+    try {
+      const weekLabels = await getWeeksWithWeeklySummaries(basePath);
+      if (weekLabels.length === 0) return [];
 
-  // Map week labels to their Monday's month
-  const monthsWithWeeklies = new Set();
-  for (const weekLabel of weekLabels) {
-    const match = weekLabel.match(/^(\d{4})-W(\d{2})$/);
-    if (!match) continue;
+      // Map week labels to their Monday's month
+      const monthsWithWeeklies = new Set();
+      for (const weekLabel of weekLabels) {
+        const match = weekLabel.match(/^(\d{4})-W(\d{2})$/);
+        if (!match) continue;
 
-    const [, yearStr, weekNumStr] = match;
-    const year = parseInt(yearStr);
-    const week = parseInt(weekNumStr);
+        const [, yearStr, weekNumStr] = match;
+        const year = parseInt(yearStr);
+        const week = parseInt(weekNumStr);
 
-    // Calculate the Monday of this ISO week
-    const jan4 = new Date(year, 0, 4);
-    const jan4Day = jan4.getDay() || 7;
-    const week1Monday = new Date(jan4);
-    week1Monday.setDate(jan4.getDate() - (jan4Day - 1));
+        // Calculate the Monday of this ISO week
+        const jan4 = new Date(year, 0, 4);
+        const jan4Day = jan4.getDay() || 7;
+        const week1Monday = new Date(jan4);
+        week1Monday.setDate(jan4.getDate() - (jan4Day - 1));
 
-    const monday = new Date(week1Monday);
-    monday.setDate(week1Monday.getDate() + (week - 1) * 7);
+        const monday = new Date(week1Monday);
+        monday.setDate(week1Monday.getDate() + (week - 1) * 7);
 
-    const monthStr = getYearMonth(monday);
-    monthsWithWeeklies.add(monthStr);
-  }
+        const monthStr = getYearMonth(monday);
+        monthsWithWeeklies.add(monthStr);
+      }
 
-  // Get current month to exclude it (timezone-aware)
-  const currentMonth = getYearMonth(getNowDate());
+      // Get current month to exclude it (timezone-aware)
+      const currentMonth = getYearMonth(getNowDate());
 
-  // Check which months already have monthly summaries
-  const summarizedMonths = await getSummarizedMonths(basePath);
+      // Check which months already have monthly summaries
+      const summarizedMonths = await getSummarizedMonths(basePath);
 
-  const unsummarized = [];
-  for (const monthStr of monthsWithWeeklies) {
-    if (monthStr >= currentMonth) continue;
-    if (summarizedMonths.has(monthStr)) continue;
-    unsummarized.push(monthStr);
-  }
+      const unsummarized = [];
+      for (const monthStr of monthsWithWeeklies) {
+        if (monthStr >= currentMonth) continue;
+        if (summarizedMonths.has(monthStr)) continue;
+        unsummarized.push(monthStr);
+      }
 
-  unsummarized.sort();
-  return unsummarized;
+      unsummarized.sort();
+      span.setAttribute('commit_story.journal.unsummarized_months_count', unsummarized.length);
+      return unsummarized;
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }


### PR DESCRIPTION
## Summary

- **Files processed**: 31
- **Committed**: 14
- **No changes needed**: 17

## Per-File Results

| File | Status | Spans | Attempts | Cost | Libraries | Schema Extensions |
|------|--------|-------|----------|------|-----------|-------------------|
| src/collectors/claude-collector.js | success | 1 | 1 | $0.18 | — | `span.commit_story.context.collect_messages` |
| src/collectors/git-collector.js | success | 6 | 3 | $0.63 | — | `span.commit_story.git.run`, `span.commit_story.git.commit_metadata`, `span.commit_story.git.commit_diff`, `span.commit_story.git.merge_info`, `span.commit_story.git.get_previous_commit_time`, `span.commit_story.git.get_commit_data`, `commit_story.git.subcommand`, `commit_story.git.diff_lines`, `commit_story.git.parent_count` |
| src/generators/journal-graph.js | success | 4 | 1 | $0.57 | `@traceloop/instrumentation-langchain` | `span.commit_story.journal.generate_summary`, `span.commit_story.journal.generate_technical`, `span.commit_story.journal.generate_dialogue`, `span.commit_story.journal.generate_sections` |
| src/generators/summary-graph.js | success | 6 | 1 | $0.59 | `@traceloop/instrumentation-langchain` | `span.commit_story.journal.daily_summary_node`, `span.commit_story.journal.generate_daily_summary`, `span.commit_story.journal.weekly_summary_node`, `span.commit_story.journal.generate_weekly_summary`, `span.commit_story.journal.monthly_summary_node`, `span.commit_story.journal.generate_monthly_summary`, `commit_story.journal.entries_count`, `commit_story.journal.week_label`, `commit_story.journal.month_label`, `commit_story.journal.summaries_count` |
| src/integrators/context-integrator.js | success | 1 | 1 | $0.25 | — | `span.commit_story.context.gather_context` |
| src/mcp/tools/context-capture-tool.js | success | 1 | 1 | $0.17 | — | `span.commit_story.context.save_context` |
| src/mcp/server.js | success | 1 | 1 | $0.05 | `@traceloop/instrumentation-mcp`, `@opentelemetry/instrumentation-pino` | `span.commit_story.mcp.main`, `commit_story.mcp.transport_type` |
| src/utils/journal-paths.js | success | 1 | 1 | $0.19 | — | `span.commit_story.journal.ensure_directory` |
| src/managers/journal-manager.js | success | 2 | 1 | $0.30 | — | `span.commit_story.journal.save_entry`, `span.commit_story.journal.discover_reflections` |
| src/managers/summary-manager.js | success | 9 | 1 | $0.62 | — | `span.commit_story.journal.read_day_entries`, `span.commit_story.journal.save_daily_summary`, `span.commit_story.journal.generate_and_save_daily_summary`, `span.commit_story.journal.read_week_daily_summaries`, `span.commit_story.journal.save_weekly_summary`, `span.commit_story.journal.generate_and_save_weekly_summary`, `span.commit_story.journal.read_month_weekly_summaries`, `span.commit_story.journal.save_monthly_summary`, `span.commit_story.journal.generate_and_save_monthly_summary` |
| src/commands/summarize.js | success | 3 | 2 | $0.63 | — | `span.commit_story.commands.run_summarize`, `span.commit_story.commands.run_weekly_summarize`, `span.commit_story.commands.run_monthly_summarize`, `commit_story.commands.dates_count`, `commit_story.commands.force` |
| src/utils/summary-detector.js | success | 9 | 1 | $0.32 | — | `span.commit_story.journal.get_days_with_entries`, `span.commit_story.journal.get_summarized_days`, `span.commit_story.journal.find_unsummarized_days`, `span.commit_story.journal.get_summarized_weeks`, `span.commit_story.journal.get_days_with_daily_summaries`, `span.commit_story.journal.find_unsummarized_weeks`, `span.commit_story.journal.get_summarized_months`, `span.commit_story.journal.get_weeks_with_weekly_summaries`, `span.commit_story.journal.find_unsummarized_months`, `commit_story.journal.unsummarized_days_count`, `commit_story.journal.unsummarized_weeks_count`, `commit_story.journal.unsummarized_months_count` |
| src/managers/auto-summarize.js | success | 3 | 1 | $0.20 | — | `span.commit_story.commands.trigger_auto_summaries`, `span.commit_story.commands.trigger_auto_weekly_summaries`, `span.commit_story.commands.trigger_auto_monthly_summaries` |
| src/index.js | success | 1 | 1 | $0.33 | — | `span.commit_story.cli.main` |

**No changes needed** (17 files, 0 spans): src/generators/prompts/guidelines/accessibility.js, src/generators/prompts/guidelines/anti-hallucination.js, src/generators/prompts/guidelines/index.js, src/generators/prompts/sections/daily-summary-prompt.js, src/generators/prompts/sections/dialogue-prompt.js, src/generators/prompts/sections/monthly-summary-prompt.js, src/generators/prompts/sections/summary-prompt.js, src/generators/prompts/sections/technical-decisions-prompt.js, src/generators/prompts/sections/weekly-summary-prompt.js, src/integrators/filters/message-filter.js, src/integrators/filters/sensitive-filter.js, src/integrators/filters/token-filter.js, src/logger.js, src/mcp/tools/reflection-tool.js, src/traceloop-init.js, src/utils/commit-analyzer.js, src/utils/config.js

## Span Category Breakdown

| File | External Calls | Schema-Defined | Service Entry Points | Total Functions |
|------|---------------|----------------|---------------------|-----------------|
| src/collectors/claude-collector.js | 0 | 0 | 1 | 8 |
| src/collectors/git-collector.js | 0 | 0 | 2 | 6 |
| src/generators/journal-graph.js | 0 | 0 | 4 | 19 |
| src/generators/summary-graph.js | 0 | 0 | 6 | 23 |
| src/integrators/context-integrator.js | 0 | 0 | 1 | 3 |
| src/mcp/tools/context-capture-tool.js | 0 | 0 | 1 | 6 |
| src/mcp/server.js | 0 | 0 | 1 | 2 |
| src/utils/journal-paths.js | 0 | 0 | 1 | 12 |
| src/managers/journal-manager.js | 0 | 0 | 2 | 12 |
| src/managers/summary-manager.js | 0 | 0 | 9 | 14 |
| src/commands/summarize.js | 0 | 0 | 3 | 9 |
| src/utils/summary-detector.js | 0 | 0 | 5 | 11 |
| src/managers/auto-summarize.js | 0 | 0 | 3 | 4 |
| src/index.js | 0 | 0 | 1 | 8 |

## Schema Changes

# Summary of Schema Changes
## Registry versions
Baseline: 0.1.0

Head: 0.1.0

## Registry Attributes
### Added
- commit_story.commands.dates_count
- commit_story.commands.force
- commit_story.git.diff_lines
- commit_story.git.parent_count
- commit_story.git.subcommand
- commit_story.journal.entries_count
- commit_story.journal.month_label
- commit_story.journal.summaries_count
- commit_story.journal.unsummarized_days_count
- commit_story.journal.unsummarized_months_count
- commit_story.journal.unsummarized_weeks_count
- commit_story.journal.week_label
- commit_story.mcp.transport_type




### New Span IDs (48)

- `span.commit_story.cli.main`
- `span.commit_story.commands.run_monthly_summarize`
- `span.commit_story.commands.run_summarize`
- `span.commit_story.commands.run_weekly_summarize`
- `span.commit_story.commands.trigger_auto_monthly_summaries`
- `span.commit_story.commands.trigger_auto_summaries`
- `span.commit_story.commands.trigger_auto_weekly_summaries`
- `span.commit_story.context.collect_messages`
- `span.commit_story.context.gather_context`
- `span.commit_story.context.save_context`
- `span.commit_story.git.commit_diff`
- `span.commit_story.git.commit_metadata`
- `span.commit_story.git.get_commit_data`
- `span.commit_story.git.get_previous_commit_time`
- `span.commit_story.git.merge_info`
- `span.commit_story.git.run`
- `span.commit_story.journal.daily_summary_node`
- `span.commit_story.journal.discover_reflections`
- `span.commit_story.journal.ensure_directory`
- `span.commit_story.journal.find_unsummarized_days`
- `span.commit_story.journal.find_unsummarized_months`
- `span.commit_story.journal.find_unsummarized_weeks`
- `span.commit_story.journal.generate_and_save_daily_summary`
- `span.commit_story.journal.generate_and_save_monthly_summary`
- `span.commit_story.journal.generate_and_save_weekly_summary`
- `span.commit_story.journal.generate_daily_summary`
- `span.commit_story.journal.generate_dialogue`
- `span.commit_story.journal.generate_monthly_summary`
- `span.commit_story.journal.generate_sections`
- `span.commit_story.journal.generate_summary`
- `span.commit_story.journal.generate_technical`
- `span.commit_story.journal.generate_weekly_summary`
- `span.commit_story.journal.get_days_with_daily_summaries`
- `span.commit_story.journal.get_days_with_entries`
- `span.commit_story.journal.get_summarized_days`
- `span.commit_story.journal.get_summarized_months`
- `span.commit_story.journal.get_summarized_weeks`
- `span.commit_story.journal.get_weeks_with_weekly_summaries`
- `span.commit_story.journal.monthly_summary_node`
- `span.commit_story.journal.read_day_entries`
- `span.commit_story.journal.read_month_weekly_summaries`
- `span.commit_story.journal.read_week_daily_summaries`
- `span.commit_story.journal.save_daily_summary`
- `span.commit_story.journal.save_entry`
- `span.commit_story.journal.save_monthly_summary`
- `span.commit_story.journal.save_weekly_summary`
- `span.commit_story.journal.weekly_summary_node`
- `span.commit_story.mcp.main`

## Review Attention

- **src/managers/summary-manager.js**: 9 spans added (average: 3) — outlier, review recommended
- **src/utils/summary-detector.js**: 9 spans added (average: 3) — outlier, review recommended

### Advisory Findings

**src/collectors/claude-collector.js**
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.

**src/collectors/git-collector.js**
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

**src/generators/journal-graph.js**
- CDQ-006 (isRecording Guard): CDQ-006 (isRecording Guard) fired because span.setAttribute() is called with an expensive computation (map, reduce, filter, JSON.stringify, etc.) or an external source string (value fetched from git output, an API response, file contents, or any source whose length is unbounded) and no span.isRecording() guard. When sampling drops the span, that work still runs on every request. Wrap the call in `if (span.isRecording()) { ... }` to skip it when the span won't be exported. Skip this finding for root spans at entry points — the guard adds clutter for negligible gain there.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

**src/generators/summary-graph.js**
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

**src/integrators/context-integrator.js**
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

**src/mcp/tools/context-capture-tool.js**
- CDQ-006 (isRecording Guard): CDQ-006 (isRecording Guard) fired because span.setAttribute() is called with an expensive computation (map, reduce, filter, JSON.stringify, etc.) or an external source string (value fetched from git output, an API response, file contents, or any source whose length is unbounded) and no span.isRecording() guard. When sampling drops the span, that work still runs on every request. Wrap the call in `if (span.isRecording()) { ... }` to skip it when the span won't be exported. Skip this finding for root spans at entry points — the guard adds clutter for negligible gain there.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

**src/mcp/tools/reflection-tool.js**
- COV-004 (Async Operation Spans): COV-004 (Async Operation Spans) fired because this async function doesn't have a span. Without one, traces have a gap here — callers can see time was spent and whether an error occurred, but not what happened inside this function. Add a span unless this is a pure synchronous utility with no I/O (RST-001 exemption) — context propagation covers unexported internal helpers.

**src/utils/journal-paths.js**
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.

**src/managers/journal-manager.js**
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.

**src/managers/summary-manager.js**
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

**src/commands/summarize.js**
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

**src/utils/summary-detector.js**
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

**src/managers/auto-summarize.js**
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- CDQ-007 (Attribute Data Quality): CDQ-007 (Attribute Data Quality) fired for one or more of: a PII attribute name (like author, email, or username) or a raw filesystem path where a basename would be safer. PII in traces can violate privacy policies and is worth fixing. The path finding is lower severity — fix it when the code will run in a context where the basename utility is already imported.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.
- SCH-001 (Span Names Match Registry): SCH-001 (Span Names Match Registry) fired because a span name doesn't match your Weaver registry or doesn't follow the required dotted-notation format (e.g. myapp.user.create). Use the registry name or declare a new span as a schemaExtension.

## Agent Notes

Each instrumented file has a companion `.instrumentation.md` file in the same directory (e.g., `src/api.js` → `src/api.instrumentation.md`) containing the agent's full decision notes.

## Recommended Companion Packages

This project was detected as a library. The following auto-instrumentation packages were identified but not added as dependencies — they are SDK-level concerns that deployers should add to their application's telemetry setup.

- `@traceloop/instrumentation-langchain`
- `@opentelemetry/instrumentation-pino`
- `@traceloop/instrumentation-mcp`

> **Important**: Initialize these packages **inside your application code**, not via `--import`. Loading them through `--import` can install a competing ESM hook registry alongside the one already registered by your OTel SDK, causing spans to be created but silently dropped — the exporter reports success but data never reaches the backend.

## SDK Bootstrap Checklist

Verify that your SDK init file includes all required resource attributes. Missing attributes reduce observability and cause RES-001 compliance failures.

```javascript
import { randomUUID } from 'node:crypto';

resource: resourceFromAttributes({
  'service.name': 'your-service-name',
  'service.version': process.env.npm_package_version || '0.0.0',
  'service.instance.id': randomUUID(),
}),
```

> **`service.instance.id`** uniquely identifies a running process instance. Without it, traces from different deployments share identical resource metadata — spans are indistinguishable across restarts and parallel processes.

## Token Usage

| | Ceiling | Actual |
|---|---------|--------|
| **Cost** | $72.54 | $5.16 |
| **Input tokens** | 3,100,000 | 110,198 |
| **Output tokens** | — | 218,392 |
| **Cache read tokens** | — | 212,599 |
| **Cache write tokens** | — | 396,588 |

Model: `claude-sonnet-4-6` | Files: 31 | Total file size: 207,087 bytes

## Live-Check Compliance

Live-Check: OK (665 spans, 4317 advisory findings — see compliance report)

Full compliance report: `spiny-orb-live-check-report.json`

## Agent Version

`1.0.0`